### PR TITLE
fix amd auto suggestion

### DIFF
--- a/xmrstak/backend/amd/autoAdjust.hpp
+++ b/xmrstak/backend/amd/autoAdjust.hpp
@@ -52,14 +52,16 @@ public:
 			return false;
 		}
 
-		devVec = getAMDDevices(0);
+		devVec = getAMDDevices(platformIndex);
 
 
 		int deviceCount = devVec.size();
 
 		if(deviceCount == 0)
-            return false;
-
+		{
+			printer::inst()->print_msg(L0,"WARNING: No AMD device found.");
+			return false;
+		}
 
         generateThreadConfig(platformIndex);
 		return true;


### PR DESCRIPTION
Platform index zero was always used to search for the device detection.

Fix: use correct detected AMD platform index

Fix bug detected from @anhphan https://github.com/fireice-uk/xmr-stak/issues/5#issuecomment-334225424