### PR TITLE
fix wrong timer for stats

### DIFF
--- a/xmrstak/misc/executor.cpp
+++ b/xmrstak/misc/executor.cpp
@@ -451,7 +451,7 @@ void executor::ex_main()
 
 				for (i = 0; i < pvThreads->size(); i++)
 				{
-					fTelem = telem->calc_telemetry_data(2500, i);
+					fTelem = telem->calc_telemetry_data(10000, i);
 					if(std::isnormal(fTelem))
 					{
 						fHps += fTelem;
@@ -730,7 +730,7 @@ void executor::http_hashrate_report(std::string& out)
 	{
 		double fHps[3];
 
-		fHps[0] = telem->calc_telemetry_data(2500, i);
+		fHps[0] = telem->calc_telemetry_data(10000, i);
 		fHps[1] = telem->calc_telemetry_data(60000, i);
 		fHps[2] = telem->calc_telemetry_data(900000, i);
 
@@ -870,7 +870,7 @@ void executor::http_json_report(std::string& out)
 		if(i != 0) hr_thds.append(1, ',');
 
 		double fHps[3];
-		fHps[0] = telem->calc_telemetry_data(2500, i);
+		fHps[0] = telem->calc_telemetry_data(10000, i);
 		fHps[1] = telem->calc_telemetry_data(60000, i);
 		fHps[2] = telem->calc_telemetry_data(900000, i);
 


### PR DESCRIPTION
fix #21, hash values randomly not available.
The reason is that I changed the lables but forget to change all timer.
A GPU needs sometimes ore than 2.5s to finish one hash round, therefore
the results are only visible randomly.