### PR TITLE
Keep consistency between class and struct

### DIFF
--- a/xmrstak/misc/environment.hpp
+++ b/xmrstak/misc/environment.hpp
@@ -7,8 +7,8 @@ class executor;
 namespace xmrstak
 {
 
-class globalStates;
-class params;
+struct globalStates;
+struct params;
 
 struct environment
 {


### PR DESCRIPTION
This fixes the msvc warning