### PR TITLE
Make sure all singletons are set to null and make env a global ptr

### DIFF
--- a/xmrstak/backend/amd/minethd.cpp
+++ b/xmrstak/backend/amd/minethd.cpp
@@ -65,7 +65,7 @@ __declspec(dllexport)
 #endif
 std::vector<iBackend*>* xmrstak_start_backend(uint32_t threadOffset, miner_work& pWork, environment& env)
 {
-	environment::inst() = env;
+	environment::inst(&env);
 	return amd::minethd::thread_starter(threadOffset, pWork);
 }
 } // extern "C"

--- a/xmrstak/backend/nvidia/minethd.cpp
+++ b/xmrstak/backend/nvidia/minethd.cpp
@@ -112,7 +112,7 @@ __declspec(dllexport)
 #endif
 std::vector<iBackend*>* xmrstak_start_backend(uint32_t threadOffset, miner_work& pWork, environment& env)
 {
-	environment::inst() = env;
+	environment::inst(&env);
 	return nvidia::minethd::thread_starter(threadOffset, pWork);
 }
 } // extern "C"

--- a/xmrstak/misc/environment.hpp
+++ b/xmrstak/misc/environment.hpp
@@ -12,35 +12,30 @@ class params;
 
 struct environment
 {
+	static inline environment& inst(environment* init = nullptr)
+	{
+		static environment* env = nullptr;
 
-	static environment& inst()
-	{
-		static environment env;
-		return env;
-	}
-	
-	environment& operator=(const environment& env)
-	{
-		this->pPrinter = env.pPrinter;
-		this->pglobalStates = env.pglobalStates;
-		this->pJconfConfig = env.pJconfConfig;
-		this->pExecutor = env.pExecutor;
-		this->pParams = env.pParams;
-		return *this;
+		if(env == nullptr)
+		{
+			if(init != nullptr)
+				env = new environment;
+			else
+				env = init;
+		}
+
+		return *env;
 	}
 
-
-	environment() : pPrinter(nullptr), pglobalStates(nullptr)
+	environment()
 	{
 	}
 
-
-	printer* pPrinter;
-	globalStates* pglobalStates;
-	jconf* pJconfConfig;
-	executor* pExecutor;
-	params* pParams;
-
+	printer* pPrinter = nullptr;
+	globalStates* pglobalStates = nullptr;
+	jconf* pJconfConfig = nullptr;
+	executor* pExecutor = nullptr;
+	params* pParams = nullptr;
 };
 
 } // namepsace xmrstak

--- a/xmrstak/misc/environment.hpp
+++ b/xmrstak/misc/environment.hpp
@@ -18,7 +18,7 @@ struct environment
 
 		if(env == nullptr)
 		{
-			if(init != nullptr)
+			if(init == nullptr)
 				env = new environment;
 			else
 				env = init;


### PR DESCRIPTION
This change makes sure of two things:
- Singleton ptr is always null at first
- We have only single env instance, so we don't duplicate singletons if we create them after the dll is loaded

Not testes at all, but should work. Let me know if there are any problems