### PR TITLE
Re-add UAC manifest and WIN_UAC cmake option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -413,6 +413,12 @@ set(LIBRARY_OUTPUT_PATH "bin")
 
 target_link_libraries(xmr-stak ${LIBS} xmr-stak-c xmr-stak-backend)
 
+option(WIN_UAC "Add UAC manifest on Windows" ON)
+
+if(WIN_UAC AND CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+    set_property(TARGET xmr-stak PROPERTY LINK_FLAGS "/level='requireAdministrator' /uiAccess='false'")
+endif()
+
 ################################################################################
 # Install
 ################################################################################

--- a/doc/compile.md
+++ b/doc/compile.md
@@ -44,6 +44,9 @@ After the configuration you need to compile the miner, follow the guide for your
   - there is no *http* interface available if option is disabled: `cmake .. -DMICROHTTPD_ENABLE=OFF`
 - `OpenSSL_ENABLE` allow to disable/enable the dependency *OpenSSL*
   - it is not possible to connect to a *https* secured pool if option is disabled: `cmake .. -DOpenSSL_ENABLE=OFF`
+- `WIN_UAC` will enable or disable the "Run As Administrator" prompt on Windows.
+  - UAC confirmation is needed to use large pages on Windows 7.
+  - On Windows 10 it is only needed once to set up the account to use them.
 
 ## CPU Build Options
 

--- a/xmrstak/cli/cli-miner.cpp
+++ b/xmrstak/cli/cli-miner.cpp
@@ -36,10 +36,6 @@
 #	include "xmrstak/http/httpd.hpp"
 #endif
 
-#ifdef _WIN32
-#	include "xmrstak/misc/uac.hpp"
-#endif
-
 #include <stdlib.h>
 #include <stdio.h>
 #include <string>
@@ -92,11 +88,6 @@ void help()
 
 int main(int argc, char *argv[])
 {
-#ifdef _WIN32
-	if (!IsElevated() && SelfElevate(argv[0]))
-		return 0;
-#endif
-
 #ifndef CONF_NO_TLS
 	SSL_library_init();
 	SSL_load_error_strings();


### PR DESCRIPTION
Thanks for help @anhphan This version includes a UAC manifest by default, since Windows 7 insists on running elevated to lock large pages.