### PR TITLE
fix illegal memory access

### DIFF
--- a/xmrstak/backend/nvidia/nvcc_code/cuda_blake.hpp
+++ b/xmrstak/backend/nvidia/nvcc_code/cuda_blake.hpp
@@ -2,7 +2,8 @@
 
 typedef struct {
 	uint32_t h[8], s[4], t[2];
-	int buflen, nullt;
+	uint32_t buflen;
+	int nullt;
 	uint8_t buf[64];
 } blake_state;
 
@@ -50,7 +51,7 @@ __constant__ uint32_t d_blake_cst[16]
 	0xC0AC29B7, 0xC97C50DD, 0x3F84D5B5, 0xB5470917
 };
 
-__device__ void cn_blake_compress(blake_state * __restrict__ S, const uint8_t * __restrict__ block)
+__device__ void cn_blake_compress(blake_state *  S, const uint8_t *  block)
 {
 	uint32_t v[16], m[16], i;
 
@@ -89,12 +90,12 @@ __device__ void cn_blake_compress(blake_state * __restrict__ S, const uint8_t * 
 	for (i = 0; i < 8;  ++i) S->h[i] ^= S->s[i % 4];
 }
 
-__device__ void cn_blake_update(blake_state * __restrict__ S, const uint8_t * __restrict__ data, uint64_t datalen)
+__device__ void cn_blake_update(blake_state *  S, const uint8_t *  data, uint64_t datalen)
 {
-	int left = S->buflen >> 3;
-	int fill = 64 - left;
+	uint32_t left = S->buflen >> 3;
+	uint32_t fill = 64 - left;
 
-	if (left && (((datalen >> 3) & 0x3F) >= (unsigned) fill)) 
+	if (left && (((datalen >> 3) & 0x3F) >= fill)) 
 	{
 		memcpy((void *) (S->buf + left), (void *) data, fill);
 		S->t[0] += 512;
@@ -125,7 +126,7 @@ __device__ void cn_blake_update(blake_state * __restrict__ S, const uint8_t * __
 	}
 }
 
-__device__ void cn_blake_final(blake_state * __restrict__ S, uint8_t * __restrict__ digest)
+__device__ void cn_blake_final(blake_state *  S, uint8_t *  digest)
 {
 	const uint8_t padding[] = 
 	{
@@ -177,7 +178,7 @@ __device__ void cn_blake_final(blake_state * __restrict__ S, uint8_t * __restric
 	U32TO8(digest + 28, S->h[7]);
 }
 
-__device__ void cn_blake(const uint8_t * __restrict__ in, uint64_t inlen, uint8_t * __restrict__ out)
+__device__ void cn_blake(const uint8_t *  in, uint64_t inlen, uint8_t *  out)
 {
 	blake_state bs;
 	blake_state *S = (blake_state *)&bs;


### PR DESCRIPTION
- remove restricted pointer
- change some sizes to `unit32_t` to avoidwrong compiler optimization

The blake algorithm code is equal to the host code implementation but the developer added to all pointer parameter the `restrict` keyword. The usage of restrict can have negative effect because the compiler is free to do many code optimizations. This can result in errors. I identified the broken line and checked why the illegal memory access was triggered. I can't find any bug expected the `restrict` keyword.
By changing some array sizes to `uint32_t` another error can be removed. It could be that this is an compiler bug (this is not the first time that some `int` optimizations created wrong code).

The bug is not triggered on all gpus (I got it with sm_70).

This PR solves closed many issues from xmr-stak-nvidia.

This PR is not increasing the register usage or the spill loads/stores.

~~**- [x] please do not merge maybe this is only workaround sometimes the issue, I am currently testing other fixes**~~