### PR TITLE
fix CUDA 9 shuffle warning

### DIFF
--- a/xmrstak/backend/nvidia/nvcc_code/cuda_core.cu
+++ b/xmrstak/backend/nvidia/nvcc_code/cuda_core.cu
@@ -156,7 +156,11 @@ __forceinline__ __device__ uint32_t shuffle(volatile uint32_t* ptr,const uint32_
 #else
     unusedVar( ptr );
     unusedVar( sub );
-    return __shfl( val, src, 4 );
+#   if(__CUDACC_VER_MAJOR__ >= 9)
+    return __shfl_sync(0xFFFFFFFF, val, src, 4 );
+#	else
+	return __shfl( val, src, 4 );
+#	endif
 #endif
 }
 


### PR DESCRIPTION
use `__shffl_snyc` if CUDA 9+ is avalable

warning:
```
xmr-stak/xmrstak/backend/nvidia/nvcc_code/cuda_core.cu(159): warning: function "__shfl(int, int, int)"
cuda_9_0/include/sm_30_intrinsics.hpp(152): here was declared deprecated ("__shfl() is not valid on compute_70 and above, and should be replaced with __shfl_sync().To continue using __shfl(), specify virtual architecture compute_60 when targeting sm_70 and above, for example, using the pair of compiler options: -arch=compute_60 -code=sm_70.")
```