### PR TITLE
prefere AMD OpenCL over NVIDIA, Intel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,6 +180,38 @@ list(APPEND CMAKE_PREFIX_PATH "$ENV{CMAKE_PREFIX_PATH}")
 
 option(OpenCL_ENABLE "Enable or disable OpenCL spport (AMD GPU support)" ON)
 if(OpenCL_ENABLE)
+    # try to find AMD OpenCL before NVIDIA OpenCL
+    find_path(OpenCL_INCLUDE_DIR
+        NAMES
+            CL/cl.h
+            OpenCL/cl.h
+        NO_DEFAULT_PATH
+        PATHS
+            ENV "OpenCL_ROOT"
+            ENV AMDAPPSDKROOT
+            ENV ATISTREAMSDKROOT
+            ENV "PROGRAMFILES(X86)"
+        PATH_SUFFIXES
+            include
+            OpenCL/common/inc
+            "AMD APP/include")
+
+    find_library(OpenCL_LIBRARY
+        NAMES 
+            OpenCL
+            OpenCL.lib
+        NO_DEFAULT_PATH
+        PATHS
+            ENV "OpenCL_ROOT"
+            ENV AMDAPPSDKROOT
+            ENV ATISTREAMSDKROOT
+            ENV "PROGRAMFILES(X86)"
+        PATH_SUFFIXES
+            "AMD APP/lib/x86_64"
+            lib/x86_64
+            lib/x64
+            OpenCL/common/lib/x64)
+    # find package will use the previews searched path variables
     find_package(OpenCL)
     if(OpenCL_FOUND)
         include_directories(SYSTEM ${OpenCL_INCLUDE_DIRS})


### PR DESCRIPTION
fix #56

Search for AMD OpenCL inlcude path and libaries to prioritize the AMD implementation over NVIDIA and Intel.

If still NVIDIA OpenCL is found it could be necessary to set the environment variable `OpenCL_ROOT` to the installation path of the AMD app SDK.

# Tests

- [ ] test on a system where  AMD and NVIDIA OpenCL ist installed