### PR TITLE
thread affinity for non cpu backends

### DIFF
--- a/xmrstak/backend/amd/minethd.cpp
+++ b/xmrstak/backend/amd/minethd.cpp
@@ -64,8 +64,9 @@ minethd::minethd(miner_work& pWork, size_t iNo, GpuContext* ctx, const jconf::th
 
 	order_guard.wait();
 
-	if(!cpu::minethd::thd_setaffinity(oWorkThd.native_handle(), affinity))
-		printer::inst()->print_msg(L1, "WARNING setting affinity failed.");
+	if(affinity >= 0) //-1 means no affinity
+		if(!cpu::minethd::thd_setaffinity(oWorkThd.native_handle(), affinity))
+			printer::inst()->print_msg(L1, "WARNING setting affinity failed.");
 }
 
 extern "C"  {

--- a/xmrstak/backend/amd/minethd.hpp
+++ b/xmrstak/backend/amd/minethd.hpp
@@ -9,6 +9,7 @@
 
 #include <thread>
 #include <atomic>
+#include <future>
 
 namespace xmrstak
 {
@@ -26,10 +27,9 @@ public:
 private:
 	typedef void (*cn_hash_fun)(const void*, size_t, void*, cryptonight_ctx*);
 	
-	minethd(miner_work& pWork, size_t iNo, GpuContext* ctx);
+	minethd(miner_work& pWork, size_t iNo, GpuContext* ctx, const jconf::thd_cfg cfg);
 	
 	void work_main();
-	void double_work_main();
 	void consume_work();
 
 	uint64_t iJobNo;
@@ -37,7 +37,10 @@ private:
 	static miner_work oGlobalWork;
 	miner_work oWork;
 
+	std::promise<void> order_fix;
+
 	std::thread oWorkThd;
+	int64_t affinity;
 
 	bool bQuit;
 	bool bNoPrefetch;

--- a/xmrstak/backend/cpu/minethd.cpp
+++ b/xmrstak/backend/cpu/minethd.cpp
@@ -259,10 +259,6 @@ std::vector<iBackend*> minethd::thread_starter(uint32_t threadOffset, miner_work
 	{
 		jconf::inst()->GetThreadConfig(i, cfg);
 
-		// \todo need thread offset
-		minethd* thd = new minethd(pWork, i + threadOffset, cfg.bDoubleMode, cfg.bNoPrefetch, cfg.iCpuAff);
-		pvThreads.push_back(thd);
-
 		if(cfg.iCpuAff >= 0)
 		{
 #if defined(__APPLE__)
@@ -273,8 +269,12 @@ std::vector<iBackend*> minethd::thread_starter(uint32_t threadOffset, miner_work
 		}
 		else
 			printer::inst()->print_msg(L1, "Starting %s thread, no affinity.", cfg.bDoubleMode ? "double" : "single");
+		
+		// \todo need thread offset
+		minethd* thd = new minethd(pWork, i + threadOffset, cfg.bDoubleMode, cfg.bNoPrefetch, cfg.iCpuAff);
+		pvThreads.push_back(thd);
 	}
-
+	
 	return pvThreads;
 }
 

--- a/xmrstak/backend/cpu/minethd.cpp
+++ b/xmrstak/backend/cpu/minethd.cpp
@@ -110,8 +110,9 @@ minethd::minethd(miner_work& pWork, size_t iNo, bool double_work, bool no_prefet
 
 	order_guard.wait();
 
-	if(!thd_setaffinity(oWorkThd.native_handle(), affinity))
-		printer::inst()->print_msg(L1, "WARNING setting affinity failed.");
+	if(affinity >= 0) //-1 means no affinity
+		if(!thd_setaffinity(oWorkThd.native_handle(), affinity))
+			printer::inst()->print_msg(L1, "WARNING setting affinity failed.");
 }
 
 cryptonight_ctx* minethd::minethd_alloc_ctx()
@@ -270,7 +271,6 @@ std::vector<iBackend*> minethd::thread_starter(uint32_t threadOffset, miner_work
 		else
 			printer::inst()->print_msg(L1, "Starting %s thread, no affinity.", cfg.bDoubleMode ? "double" : "single");
 		
-		// \todo need thread offset
 		minethd* thd = new minethd(pWork, i + threadOffset, cfg.bDoubleMode, cfg.bNoPrefetch, cfg.iCpuAff);
 		pvThreads.push_back(thd);
 	}

--- a/xmrstak/backend/nvidia/minethd.cpp
+++ b/xmrstak/backend/nvidia/minethd.cpp
@@ -82,8 +82,9 @@ minethd::minethd(miner_work& pWork, size_t iNo, const jconf::thd_cfg& cfg)
 
 	order_guard.wait();
 
-	if(!cpu::minethd::thd_setaffinity(oWorkThd.native_handle(), affinity))
-		printer::inst()->print_msg(L1, "WARNING setting affinity failed.");
+	if(affinity >= 0) //-1 means no affinity
+		if(!cpu::minethd::thd_setaffinity(oWorkThd.native_handle(), affinity))
+			printer::inst()->print_msg(L1, "WARNING setting affinity failed.");
 }
 
 

--- a/xmrstak/backend/nvidia/minethd.hpp
+++ b/xmrstak/backend/nvidia/minethd.hpp
@@ -12,6 +12,7 @@
 #include <thread>
 #include <atomic>
 #include <vector>
+#include <future>
 
 
 namespace xmrstak
@@ -43,7 +44,10 @@ private:
 	static miner_work oGlobalWork;
 	miner_work oWork;
 
+	std::promise<void> order_fix;
+
 	std::thread oWorkThd;
+	int64_t affinity;
 
 	nvid_ctx ctx;
 


### PR DESCRIPTION
This is a follow up of #43 and use the some mechanism to set the thread affinity for
non cpu backends correct.

- use cpu affinity workflow for nvidia and amd
- amd/nvidia: bind host memory with numaloc if affinity is given
- cpu: move messages of thread spawning before thread creation