### PR TITLE
fix windows compile and broken aeon

### DIFF
--- a/xmrstak/backend/cpu/hwlocMemory.cpp
+++ b/xmrstak/backend/cpu/hwlocMemory.cpp
@@ -1,0 +1,64 @@
+#include "xmrstak/backend/cpu/hwlocMemory.hpp"
+
+#ifndef CONF_NO_HWLOC
+
+#include "xmrstak/misc/console.hpp"
+
+#include <hwloc.h>
+
+/** pin memory to NUMA node
+ *
+ * Set the default memory policy for the current thread to bind memory to the
+ * NUMA node.
+ *
+ * @param puId core id
+ */
+void bindMemoryToNUMANode( size_t puId )
+{
+	int depth;
+	hwloc_topology_t topology;
+
+	hwloc_topology_init(&topology);
+	hwloc_topology_load(topology);
+
+	if(!hwloc_topology_get_support(topology)->membind->set_thisthread_membind)
+	{
+		printer::inst()->print_msg(L0, "hwloc: set_thisthread_membind not supported");
+		hwloc_topology_destroy(topology);
+		return;
+	}
+
+	depth = hwloc_get_type_depth(topology, HWLOC_OBJ_PU);
+
+	for( size_t i = 0;
+		i < hwloc_get_nbobjs_by_depth(topology, depth);
+		i++ )
+	{
+		hwloc_obj_t pu = hwloc_get_obj_by_depth(topology, depth, i);
+		if(  pu->os_index == puId )
+		{
+			if( 0 > hwloc_set_membind_nodeset(
+				topology,
+				pu->nodeset,
+				HWLOC_MEMBIND_BIND,
+				HWLOC_MEMBIND_THREAD))
+			{
+				printer::inst()->print_msg(L0, "hwloc: can't bind memory");
+			}
+			else
+			{
+				printer::inst()->print_msg(L0, "hwloc: memory pinned");
+				break;
+			}
+		}
+	}
+
+	hwloc_topology_destroy(topology);
+}
+#else
+
+void bindMemoryToNUMANode( size_t )
+{
+}
+
+#endif

--- a/xmrstak/backend/cpu/hwlocMemory.hpp
+++ b/xmrstak/backend/cpu/hwlocMemory.hpp
@@ -1,10 +1,6 @@
 #pragma once
 
-#include "xmrstak/misc/console.hpp"
-
-#ifndef CONF_NO_HWLOC
-
-#include <hwloc.h>
+#include <cstddef>
 
 /** pin memory to NUMA node
  *
@@ -13,52 +9,4 @@
  *
  * @param puId core id
  */
-void bindMemoryToNUMANode( size_t puId )
-{
-	int depth;
-	hwloc_topology_t topology;
-
-	hwloc_topology_init(&topology);
-	hwloc_topology_load(topology);
-
-	if(!hwloc_topology_get_support(topology)->membind->set_thisthread_membind)
-	{
-		printer::inst()->print_msg(L0, "hwloc: set_thisthread_membind not supported");
-		hwloc_topology_destroy(topology);
-		return;
-	}
-
-	depth = hwloc_get_type_depth(topology, HWLOC_OBJ_PU);
-
-	for( size_t i = 0;
-		i < hwloc_get_nbobjs_by_depth(topology, depth);
-		i++ )
-	{
-		hwloc_obj_t pu = hwloc_get_obj_by_depth(topology, depth, i);
-		if(  pu->os_index == puId )
-		{
-			if( 0 > hwloc_set_membind_nodeset(
-				topology,
-				pu->nodeset,
-				HWLOC_MEMBIND_BIND,
-				HWLOC_MEMBIND_THREAD))
-			{
-				printer::inst()->print_msg(L0, "hwloc: can't bind memory");
-			}
-			else
-			{
-				printer::inst()->print_msg(L0, "hwloc: memory pinned");
-				break;
-			}
-		}
-	}
-
-	hwloc_topology_destroy(topology);
-}
-#else
-
-void bindMemoryToNUMANode( size_t )
-{
-}
-
-#endif
+void bindMemoryToNUMANode( size_t puId );

--- a/xmrstak/backend/nvidia/minethd.cpp
+++ b/xmrstak/backend/nvidia/minethd.cpp
@@ -222,7 +222,6 @@ void minethd::work_main()
 	}
 
 	bool mineMonero = strcmp_i(::jconf::inst()->GetCurrency(), "monero");
-	bool useAEON = strcmp_i(::jconf::inst()->GetCurrency(), "aeon");
 	
 	while (bQuit == 0)
 	{
@@ -261,18 +260,9 @@ void minethd::work_main()
 			uint32_t foundCount;
 
 			cryptonight_extra_cpu_prepare(&ctx, iNonce);
-#ifndef CONF_NO_MONERO
-			if(mineMonero)
-			{
-				cryptonight_core_cpu_hash<MONERO_ITER, MONERO_MASK, 19>(&ctx);
-			}
-#endif
-#ifndef CONF_NO_AEON
-			if(useAEON)
-			{
-				cryptonight_core_cpu_hash<MONERO_ITER, MONERO_MASK, 18>(&ctx);
-			}
-#endif
+
+			cryptonight_core_cpu_hash(&ctx, mineMonero);
+
 			cryptonight_extra_cpu_final(&ctx, iNonce, oWork.iTarget, &foundCount, foundNonce);
 
 			for(size_t i = 0; i < foundCount; i++)

--- a/xmrstak/backend/nvidia/minethd.hpp
+++ b/xmrstak/backend/nvidia/minethd.hpp
@@ -4,7 +4,7 @@
 #include "jconf.hpp"
 #include "nvcc_code/cryptonight.hpp"
 
-#include "xmrstak/backend/cpu/crypto/cryptonight.h"
+#include "xmrstak/backend/cpu/minethd.hpp"
 #include "xmrstak/backend/iBackend.hpp"
 #include "xmrstak/misc/environment.hpp"
 

--- a/xmrstak/backend/nvidia/nvcc_code/cryptonight.hpp
+++ b/xmrstak/backend/nvidia/nvcc_code/cryptonight.hpp
@@ -44,6 +44,4 @@ void cryptonight_extra_cpu_prepare(nvid_ctx* ctx, uint32_t startNonce);
 void cryptonight_extra_cpu_final(nvid_ctx* ctx, uint32_t startNonce, uint64_t target, uint32_t* rescount, uint32_t *resnonce);
 }
 
-template<size_t ITERATIONS, size_t THREAD_SHIFT, uint32_t MASK>
-void cryptonight_core_cpu_hash(nvid_ctx* ctx);
-
+void cryptonight_core_cpu_hash(nvid_ctx* ctx, bool mineMonero);


### PR DESCRIPTION
- fix windows linker error during compile #75
  - create file `hwlocMemory.cpp`
- fix wrong parameter to call aeon (nvidia-backend)
  - move compile time specialization to CUDA code file

After fixing #75 there was a second compile issue in the nvidia-backend. 
I realized that the nvidia aeon and xmr support in the current dev is broken. I used the wrong order for two template arguments and used the monero parameter for aeon. I don't know how I passed my tests (maybe dirty environment)

# Tests
I repeated the tests for aeon and monero on a clean environment.
- [x] NVIDIA Monero
- [x] NVIDIA Aeon
- [x] Windows compile
- [x] Windows CPU