### PR TITLE
add option: flush stdout

### DIFF
--- a/xmrstak/config.tpl
+++ b/xmrstak/config.tpl
@@ -140,6 +140,14 @@ R"===(
 "daemon_mode" : false,
 
 /*
+ * Buffered output control.
+ * When running the miner through a pipe, standard output is buffered. This means that the pipe won't read
+ * each output line immediately. This can cause delays when running in background.
+ * Set this option to true to flush stdout after each line, so it can be read immediately.
+ */
+ "flush_stdout" : false,
+
+/*
  * Output file
  *
  * output_file  - This option will log all output to a file.

--- a/xmrstak/jconf.cpp
+++ b/xmrstak/jconf.cpp
@@ -48,7 +48,7 @@ using namespace rapidjson;
  */
 enum configEnum {
 	bTlsMode, bTlsSecureAlgo, sTlsFingerprint, sPoolAddr, sWalletAddr, sPoolPwd,sCurrency,
-	iCallTimeout, iNetRetry, iGiveUpLimit, iVerboseLevel, iAutohashTime,
+	iCallTimeout, iNetRetry, iGiveUpLimit, iVerboseLevel, iAutohashTime,bFlushStdout,
 	bDaemonMode, sOutputFile, iHttpdPort, bPreferIpv4, bNiceHashMode, bAesOverride, sUseSlowMem };
 
 struct configVal {
@@ -72,6 +72,7 @@ configVal oConfigValues[] = {
 	{ iGiveUpLimit, "giveup_limit", kNumberType },
 	{ iVerboseLevel, "verbose_level", kNumberType },
 	{ iAutohashTime, "h_print_time", kNumberType },
+	{ bFlushStdout, "flush_stdout", kTrueType},
 	{ bDaemonMode, "daemon_mode", kTrueType },
 	{ sOutputFile, "output_file", kStringType },
 	{ iHttpdPort, "httpd_port", kNumberType },
@@ -447,6 +448,16 @@ bool jconf::parse_config(const char* sFilename)
 		return false;
 	}
 #endif // _WIN32
+
+	if (prv->configValues[bFlushStdout]->IsBool())
+	{
+		bool bflush = prv->configValues[bFlushStdout]->GetBool();
+		printer::inst()->set_flush_stdout(bflush);
+		if (bflush)
+		{
+			printer::inst()->print_msg(L0, "Flush stdout forced.");
+		}
+	}
 
 	return true;
 }

--- a/xmrstak/misc/console.cpp
+++ b/xmrstak/misc/console.cpp
@@ -156,6 +156,7 @@ printer::printer()
 {
 	verbose_level = LINF;
 	logfile = nullptr;
+	b_flush_stdout = false;
 }
 
 bool printer::open_logfile(const char* file)
@@ -192,6 +193,11 @@ void printer::print_msg(verbosity verbose, const char* fmt, ...)
 
 	std::unique_lock<std::mutex> lck(print_mutex);
 	fputs(buf, stdout);
+
+	if (b_flush_stdout)
+	{
+		fflush(stdout);
+	}
 
 	if(logfile != nullptr)
 	{

--- a/xmrstak/misc/console.hpp
+++ b/xmrstak/misc/console.hpp
@@ -35,6 +35,7 @@ public:
 	};
 
 	inline void set_verbose_level(size_t level) { verbose_level = (verbosity)level; }
+	inline void set_flush_stdout(bool status) { b_flush_stdout = status; }
 	void print_msg(verbosity verbose, const char* fmt, ...);
 	void print_str(const char* str);
 	bool open_logfile(const char* file);
@@ -44,6 +45,7 @@ private:
 
 	std::mutex print_mutex;
 	verbosity verbose_level;
+	bool b_flush_stdout;
 	FILE* logfile;
 };
 


### PR DESCRIPTION
Added the option to forcefully flush STDOUT, which may be useful when running the miner through a pipe instead than a shell.
If STDOUT is a shell, it's unbuffered by default.
If STDOUT is a pipe, it's buffered by default.


This PR is ported from https://github.com/fireice-uk/xmr-stak-cpu/pull/352 to the new miner base.