### PR TITLE
fix OSX compile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -429,9 +429,7 @@ if(CUDA_FOUND)
         )
     endif()
     target_link_libraries(xmrstak_cuda_backend ${CUDA_LIBRARIES})
-    if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
-        target_link_libraries(xmrstak_cuda_backend xmr-stak-backend)
-    endif()
+    target_link_libraries(xmrstak_cuda_backend xmr-stak-backend)
 endif()
 
 # compile AMD backend
@@ -444,9 +442,7 @@ if(OpenCL_FOUND)
         ${OPENCLSRCFILES}
     )
     target_link_libraries(xmrstak_opencl_backend ${OpenCL_LIBRARY} )
-    if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
-        target_link_libraries(xmrstak_opencl_backend xmr-stak-backend)
-    endif()
+    target_link_libraries(xmrstak_opencl_backend xmr-stak-backend)
 endif()
 
 # compile final binary

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -358,6 +358,8 @@ endif()
 
 include_directories(BEFORE .)
 
+set (CMAKE_POSITION_INDEPENDENT_CODE TRUE)
+
 if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
     # remove warnings that f_open() is not save and f_open_s should be used
     add_definitions(-D_CRT_SECURE_NO_DEPRECATE)


### PR DESCRIPTION
fix #71 

- link `xmr-stak-backend` to `xmrstak_cuda_backend` to solve missing symbols

Before this PR the symboles of `console.hpp, ...` was linked only on windows to CUDA  and OpenCL. This can result in missing symbols. 