### PR TITLE
OSX file file extension (dynamic libraries)

### DIFF
--- a/xmrstak/backend/plugin.hpp
+++ b/xmrstak/backend/plugin.hpp
@@ -37,7 +37,13 @@ struct plugin
 			return;
 		}
 #else
-		libBackend = dlopen((params::inst().executablePrefix + "/lib" + libName + ".so").c_str(), RTLD_LAZY);
+		// `.so` linux file extention for dynamic libraries
+		std::string fileExtension = ".so";
+#	if defined(__APPLE__)
+		// `.dylib` Mac OS X file extention for dynamic libraries
+		fileExtension = ".dylib";
+#	endif
+		libBackend = dlopen((params::inst().executablePrefix + "/lib" + libName + fileExtension).c_str(), RTLD_LAZY);
 		if(!libBackend)
 		{
 			std::cerr << "WARNING: "<< m_backendName <<" cannot load backend library: " << dlerror() << std::endl;


### PR DESCRIPTION
fix #71 (can't find back-end library)
This is a follow up of #84.

- use `.dylib` as dynamic library file extension