### PR TITLE
optimize NVIDIA autosuggestion

### DIFF
--- a/xmrstak/backend/nvidia/autoAdjust.hpp
+++ b/xmrstak/backend/nvidia/autoAdjust.hpp
@@ -88,17 +88,18 @@ private:
 
 		constexpr size_t byte2mib = 1024u * 1024u;
 		std::string conf;
-        int i = 0;
         for(auto& ctx : nvidCtxVec)
         {
-			conf += std::string("  // gpu: ") + ctx.name + " architecture: " + std::to_string(ctx.device_arch[0] * 10 + ctx.device_arch[1]) + "\n";
-			conf += std::string("  //      memory: ") + std::to_string(ctx.free_device_memory / byte2mib) + "/"  + std::to_string(ctx.total_device_memory / byte2mib) + " MiB\n";
-            conf += std::string("  { \"index\" : ") + std::to_string(ctx.device_id) + ",\n" +
-                "    \"threads\" : " + std::to_string(ctx.device_threads) + ", \"blocks\" : " + std::to_string(ctx.device_blocks) + ",\n" +
-                "    \"bfactor\" : " + std::to_string(ctx.device_bfactor) + ", \"bsleep\" :  " + std::to_string(ctx.device_bsleep) + ",\n" +
-                "    \"affine_to_cpu\" : false,\n" +
-                "  },\n";
-            ++i;
+			if(ctx.device_threads * ctx.device_blocks > 0)
+			{
+				conf += std::string("  // gpu: ") + ctx.name + " architecture: " + std::to_string(ctx.device_arch[0] * 10 + ctx.device_arch[1]) + "\n";
+				conf += std::string("  //      memory: ") + std::to_string(ctx.free_device_memory / byte2mib) + "/"  + std::to_string(ctx.total_device_memory / byte2mib) + " MiB\n";
+				conf += std::string("  { \"index\" : ") + std::to_string(ctx.device_id) + ",\n" +
+					"    \"threads\" : " + std::to_string(ctx.device_threads) + ", \"blocks\" : " + std::to_string(ctx.device_blocks) + ",\n" +
+					"    \"bfactor\" : " + std::to_string(ctx.device_bfactor) + ", \"bsleep\" :  " + std::to_string(ctx.device_bsleep) + ",\n" +
+					"    \"affine_to_cpu\" : false,\n" +
+					"  },\n";
+			}
         }
 
 		configTpl.replace("GPUCONFIG",conf);


### PR DESCRIPTION
- avoid creation of a config with zero threads or blocks
- WINDOWS: reduce the used memory for the auto suggestion by the amount of already used memory

We use in windows bfactor (split slow kernel into smaller parts) to avoid that windows is killing long running kernel.
In the case there is already memory used on the gpu than we assume that other application are running between the split kernel, this can result into TLB memory flushes and can strongly reduce the performance and the result can be that windows is killing the miner.
Be reducing maximum memory for the autosuggestion be the amount of the current used memory we try to avoid this effect.

- [x] do not merge before we get feedback from @sheepchen

This PR is related to #88