### PR TITLE
Disable sigpipe on posix systems

### DIFF
--- a/xmrstak/misc/executor.cpp
+++ b/xmrstak/misc/executor.cpp
@@ -449,8 +449,26 @@ void executor::on_miner_result(size_t pool_id, job_result& oResult)
 	}
 }
 
+#ifndef _WIN32
+
+#include <signal.h>
+void disable_sigpipe()
+{
+	struct sigaction sa;
+	sa.sa_handler = SIG_IGN;
+	sa.sa_flags = 0;
+	if (sigaction(SIGPIPE, &sa, 0) == -1)
+		printer::inst()->print_msg(L1, "ERROR: Call to sigaction failed!");
+}
+
+#else
+inline void disable_sigpipe() {}
+#endif
+
 void executor::ex_main()
 {
+	disable_sigpipe();
+
 	assert(1000 % iTickTime == 0);
 
 	xmrstak::miner_work oWork = xmrstak::miner_work();


### PR DESCRIPTION
Linux will terminate an network application randomly unless this is disabled. Not a large issue on the miner (on the pool it only became a problem over 1000 connections per minute), but can happen.