### PR TITLE
improve cli hash report

### DIFF
--- a/xmrstak/backend/amd/minethd.cpp
+++ b/xmrstak/backend/amd/minethd.cpp
@@ -49,6 +49,7 @@ namespace amd
 
 minethd::minethd(miner_work& pWork, size_t iNo, GpuContext* ctx, const jconf::thd_cfg cfg)
 {
+	this->backendType = iBackend::AMD;
 	oWork = pWork;
 	bQuit = 0;
 	iThreadNo = (uint8_t)iNo;

--- a/xmrstak/backend/cpu/minethd.cpp
+++ b/xmrstak/backend/cpu/minethd.cpp
@@ -94,6 +94,7 @@ bool minethd::thd_setaffinity(std::thread::native_handle_type h, uint64_t cpu_id
 
 minethd::minethd(miner_work& pWork, size_t iNo, bool double_work, bool no_prefetch, int64_t affinity)
 {
+	this->backendType = iBackend::CPU;
 	oWork = pWork;
 	bQuit = 0;
 	iThreadNo = (uint8_t)iNo;

--- a/xmrstak/backend/iBackend.hpp
+++ b/xmrstak/backend/iBackend.hpp
@@ -5,15 +5,31 @@
 #include <atomic>
 #include <cstdint>
 #include <climits>
-
+#include <vector>
+#include <string>
 
 namespace xmrstak
 {
 	struct iBackend
 	{
+
+		enum BackendType : uint32_t { UNKNOWN = 0, CPU = 1u, AMD = 2u, NVIDIA = 3u };
+		
+		static std::string getName(const BackendType type)
+		{
+			std::vector<std::string> backendNames = {
+				"UNKNOWN",
+				"CPU",
+				"AMD",
+				"NVIDIA"
+			};
+			return backendNames[static_cast<uint32_t>(type)];
+		}
+
 		std::atomic<uint64_t> iHashCount;
 		std::atomic<uint64_t> iTimestamp;
 		uint32_t iThreadNo;
+		BackendType backendType = UNKNOWN;
 
 		iBackend() : iHashCount(0), iTimestamp(0)
 		{

--- a/xmrstak/backend/nvidia/minethd.cpp
+++ b/xmrstak/backend/nvidia/minethd.cpp
@@ -66,6 +66,7 @@ namespace nvidia
 	
 minethd::minethd(miner_work& pWork, size_t iNo, const jconf::thd_cfg& cfg)
 {
+	this->backendType = iBackend::NVIDIA;
 	oWork = pWork;
 	bQuit = 0;
 	iThreadNo = (uint8_t)iNo;


### PR DESCRIPTION
close #8

- add type of the backend to each backend-plugin
- add `gteName` to `iBackend` to get the name of the backend
- report hash rate per backend

# Future Improvements for follow up PR
- split hash report for web interface and the json
- add total hash rate per backend

```
HASHRATE REPORT - CPU
| ID | 10s |  60s |  15m | ID | 10s |  60s |  15m |
|  0 | 65.0 | 64.9 | (na) |  1 | 40.3 | 40.1 | (na) |
|  2 | 40.4 | 40.1 | (na) |  3 | 41.6 | 41.4 | (na) |
|  4 | 65.5 | 65.2 | (na) |  5 | 40.6 | 40.5 | (na) |
|  6 | 40.6 | 40.6 | (na) |  7 | 41.7 | 41.5 | (na) |
-----------------------------------------------------
HASHRATE REPORT - NVIDIA
| ID | 10s |  60s |  15m | ID | 10s |  60s |  15m |
|  0 | 39.1 | 39.3 | (na) |  1 | 39.6 | 39.9 | (na) |
|  2 | 37.6 | 37.2 | (na) |  3 | 39.8 | 39.5 | (na) |
-----------------------------------------------------
Totals:   194.8 193.1 (na) H/s
Highest:  194.3 H/s
```