### PR TITLE
Fix misc bugs

### DIFF
--- a/xmrstak/backend/amd/minethd.hpp
+++ b/xmrstak/backend/amd/minethd.hpp
@@ -38,6 +38,7 @@ private:
 	miner_work oWork;
 
 	std::promise<void> order_fix;
+	std::mutex thd_aff_set;
 
 	std::thread oWorkThd;
 	int64_t affinity;

--- a/xmrstak/backend/cpu/minethd.cpp
+++ b/xmrstak/backend/cpu/minethd.cpp
@@ -102,6 +102,7 @@ minethd::minethd(miner_work& pWork, size_t iNo, bool double_work, bool no_prefet
 	bNoPrefetch = no_prefetch;
 	this->affinity = affinity;
 
+	std::unique_lock<std::mutex> lck(thd_aff_set);
 	std::future<void> order_guard = order_fix.get_future();
 
 	if(double_work)
@@ -340,6 +341,9 @@ void minethd::work_main()
 		bindMemoryToNUMANode(affinity);
 
 	order_fix.set_value();
+	std::unique_lock<std::mutex> lck(thd_aff_set);
+	lck.release();
+	std::this_thread::yield();
 
 	cn_hash_fun hash_fun;
 	cryptonight_ctx* ctx;
@@ -467,6 +471,9 @@ void minethd::double_work_main()
 		bindMemoryToNUMANode(affinity);
 
 	order_fix.set_value();
+	std::unique_lock<std::mutex> lck(thd_aff_set);
+	lck.release();
+	std::this_thread::yield();
 
 	cn_hash_fun_dbl hash_fun;
 	cryptonight_ctx* ctx0;

--- a/xmrstak/backend/cpu/minethd.hpp
+++ b/xmrstak/backend/cpu/minethd.hpp
@@ -46,6 +46,7 @@ private:
 	miner_work oWork;
 
 	std::promise<void> order_fix;
+	std::mutex thd_aff_set;
 
 	std::thread oWorkThd;
 	int64_t affinity;

--- a/xmrstak/backend/nvidia/minethd.hpp
+++ b/xmrstak/backend/nvidia/minethd.hpp
@@ -45,6 +45,7 @@ private:
 	miner_work oWork;
 
 	std::promise<void> order_fix;
+	std::mutex thd_aff_set;
 
 	std::thread oWorkThd;
 	int64_t affinity;

--- a/xmrstak/cli/cli-miner.cpp
+++ b/xmrstak/cli/cli-miner.cpp
@@ -130,7 +130,11 @@ std::string get_multipool_entry(bool& final)
 	std::cout<<"- Password (mostly empty or x):"<<std::endl;
 	getline(std::cin, passwd);
 
+#ifdef CONF_NO_TLS
+	bool tls = false;
+#else
 	bool tls = read_yes_no("- Does this pool port support TLS/SSL? Use no if unknown. (y/N)");
+#endif
 	bool nicehash = read_yes_no("- Do you want to use nicehash on this pool? (y/n)");
 
 	int64_t pool_weight;
@@ -207,7 +211,11 @@ void do_guided_config(bool userSetPasswd)
 		getline(std::cin, passwd);
 	}
 
+#ifdef CONF_NO_TLS
+	bool tls = false;
+#else
 	bool tls = read_yes_no("- Does this pool port support TLS/SSL? Use no if unknown. (y/N)");
+#endif
 	bool nicehash = read_yes_no("- Do you want to use nicehash on this pool? (y/n)");
 	
 	bool multipool;

--- a/xmrstak/jconf.cpp
+++ b/xmrstak/jconf.cpp
@@ -484,15 +484,6 @@ bool jconf::parse_config(const char* sFilename)
 		return false;
 	}
 
-#ifdef CONF_NO_TLS
-	if(prv->configValues[bTlsMode]->GetBool())
-	{
-		printer::inst()->print_msg(L0,
-			"Invalid config file. TLS enabled while the application has been compiled without TLS support.");
-		return false;
-	}
-#endif // CONF_NO_TLS
-
 	if(prv->configValues[bAesOverride]->IsBool())
 		bHaveAes = prv->configValues[bAesOverride]->GetBool();
 

--- a/xmrstak/misc/executor.cpp
+++ b/xmrstak/misc/executor.cpp
@@ -494,6 +494,13 @@ void executor::ex_main()
 	{
 		jconf::pool_cfg cfg;
  		jconf::inst()->GetPoolConfig(i, cfg);
+#ifdef CONF_NO_TLS
+		if(cfg.tls)
+		{
+			printer::inst()->print_msg(L1, "ERROR: No miner was compiled without TLS support.");
+			win_exit();
+		}
+#endif
 		if(!cfg.tls) tls = false;
 		pools.emplace_back(i+1, cfg.sPoolAddr, cfg.sWalletAddr, cfg.sPasswd, cfg.weight, false, cfg.tls, cfg.tls_fingerprint, cfg.nicehash);
 	}

--- a/xmrstak/misc/executor.cpp
+++ b/xmrstak/misc/executor.cpp
@@ -559,6 +559,10 @@ void executor::ex_main()
 			eval_pool_choice();
 			break;
 
+		case EV_GPU_RES_ERROR:
+			log_result_error(ev.oGpuError.error_str);
+			break;
+
 		case EV_PERF_TICK:
 			for (i = 0; i < pvThreads->size(); i++)
 				telem->push_perf_value(i, pvThreads->at(i)->iHashCount.load(std::memory_order_relaxed),

--- a/xmrstak/misc/executor.hpp
+++ b/xmrstak/misc/executor.hpp
@@ -42,7 +42,6 @@ public:
 
 	inline void push_event(ex_event&& ev) { oEventQ.push(std::move(ev)); }
 	void push_timed_event(ex_event&& ev, size_t sec);
-	void log_result_error(std::string&& sError);
 
 private:
 	struct timed_event
@@ -180,6 +179,7 @@ private:
 	double fHighestHps = 0.0;
 
 	void log_socket_error(jpsock* pool, std::string&& sError);
+	void log_result_error(std::string&& sError);
 	void log_result_ok(uint64_t iActualDiff);
 
 	void on_sock_ready(size_t pool_id);

--- a/xmrstak/net/msgstruct.hpp
+++ b/xmrstak/net/msgstruct.hpp
@@ -62,7 +62,14 @@ struct sock_err
 	sock_err& operator=(sock_err const&) = delete;
 };
 
-enum ex_event_name { EV_INVALID_VAL, EV_SOCK_READY, EV_SOCK_ERROR,
+// Unlike socket errors, GPU errors are read-only strings
+struct gpu_res_err
+{
+	const char* error_str;
+	gpu_res_err(const char* error_str) : error_str(error_str) {}
+};
+
+enum ex_event_name { EV_INVALID_VAL, EV_SOCK_READY, EV_SOCK_ERROR, EV_GPU_RES_ERROR,
 	EV_POOL_HAVE_JOB, EV_MINER_HAVE_RESULT, EV_PERF_TICK, EV_EVAL_POOL_CHOICE, 
 	EV_USR_HASHRATE, EV_USR_RESULTS, EV_USR_CONNSTAT, EV_HASHRATE_LOOP, 
 	EV_HTML_HASHRATE, EV_HTML_RESULTS, EV_HTML_CONNSTAT, EV_HTML_JSON };
@@ -87,9 +94,11 @@ struct ex_event
 		pool_job oPoolJob;
 		job_result oJobResult;
 		sock_err oSocketError;
+		gpu_res_err oGpuError;
 	};
 
 	ex_event() { iName = EV_INVALID_VAL; iPoolId = 0;}
+	ex_event(const char* gpu_err, size_t id) : iName(EV_GPU_RES_ERROR), iPoolId(id), oGpuError(gpu_err) {}
 	ex_event(std::string&& err, bool silent, size_t id) : iName(EV_SOCK_ERROR), iPoolId(id), oSocketError(std::move(err), silent) { }
 	ex_event(job_result dat, size_t id) : iName(EV_MINER_HAVE_RESULT), iPoolId(id), oJobResult(dat) {}
 	ex_event(pool_job dat, size_t id) : iName(EV_POOL_HAVE_JOB), iPoolId(id), oPoolJob(dat) {}


### PR DESCRIPTION
Three issues 

- CONF_NO_TLS option wasn't handled properly
- log_result_error has been made public, which resulted in a threading violation
- DeadToo's idea of returning to scheduler after a pin but before mem allocation.