### PR TITLE
Fix GPU result crash

### DIFF
--- a/xmrstak/misc/executor.cpp
+++ b/xmrstak/misc/executor.cpp
@@ -561,7 +561,7 @@ void executor::ex_main()
 			break;
 
 		case EV_GPU_RES_ERROR:
-			log_result_error(ev.oGpuError.error_str);
+			log_result_error(std::string(ev.oGpuError.error_str));
 			break;
 
 		case EV_PERF_TICK:

--- a/xmrstak/net/msgstruct.hpp
+++ b/xmrstak/net/msgstruct.hpp
@@ -125,6 +125,8 @@ struct ex_event
 		case EV_POOL_HAVE_JOB:
 			oPoolJob = from.oPoolJob;
 			break;
+		case EV_GPU_RES_ERROR:
+			oGpuError = from.oGpuError;
 		default:
 			break;
 		}
@@ -152,6 +154,8 @@ struct ex_event
 		case EV_POOL_HAVE_JOB:
 			oPoolJob = from.oPoolJob;
 			break;
+		case EV_GPU_RES_ERROR:
+			oGpuError = from.oGpuError;
 		default:
 			break;
 		}


### PR DESCRIPTION
Fairly trivial issue - forgot to add copy code so the application tried to read random memory.

I added an explicit constructor too, just to make it clearer what is happening.