### PR TITLE
fix max work size shown to user

### DIFF
--- a/xmrstak/backend/amd/amd_gpu/gpu.cpp
+++ b/xmrstak/backend/amd/amd_gpu/gpu.cpp
@@ -226,6 +226,10 @@ size_t InitOpenCLGpu(cl_context opencl_ctx, GpuContext* ctx, const char* source_
 		return ERR_OCL_API;
 	}
 
+	/* Some kernel spawn 8 times more threads than the user is configuring.
+	 * To give the user the correct maximum work size we divide the hardware specific max by 8.
+	 */
+	MaximumWorkSize /= 8;
 	printer::inst()->print_msg(L1,"Device %lu work size %lu / %lu.", ctx->deviceIdx, ctx->workSize, MaximumWorkSize);
 #ifdef CL_VERSION_2_0
 	const cl_queue_properties CommandQueueProperties[] = { 0, 0, 0 };


### PR DESCRIPTION
The max work size shown to the user was the hardware maximum but not take in account thet some kernel spwning 8 times more threads per work group than configured by the user.