### PR TITLE
fix broken windows compile with v140

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -446,7 +446,7 @@ add_library(xmr-stak-c
     ${SRCFILES_C}
 )
 set_property(TARGET xmr-stak-c PROPERTY C_STANDARD 99)
-target_link_libraries(xmr-stak-c ${LIBS})
+target_link_libraries(xmr-stak-c ${MHTD} ${LIBS})
 
 # compile generic backend files
 file(GLOB BACKEND_CPP


### PR DESCRIPTION
This will fix linker issues I had on two different Windows systems.

add microhttpd libs explicit to `xmr-stak-c`