### PR TITLE
Fix indent on hash rate report. 

### DIFF
--- a/xmrstak/misc/executor.cpp
+++ b/xmrstak/misc/executor.cpp
@@ -624,7 +624,10 @@ inline const char* hps_format(double h, char* buf, size_t l)
 {
 	if(std::isnormal(h) || h == 0.0)
 	{
-		snprintf(buf, l, " %03.1f", h);
+		if(h < 10.0)
+			snprintf(buf, l, "  %03.1f", h);
+		else
+			snprintf(buf, l, " %04.1f", h);
 		return buf;
 	}
 	else
@@ -722,9 +725,9 @@ void executor::hashrate_report(std::string& out)
 			std::transform(name.begin(), name.end(), name.begin(), ::toupper);
 			
 			out.append("HASHRATE REPORT - ").append(name).append("\n");
-			out.append("| ID | 10s |  60s |  15m |");
+			out.append("| ID |  10s |  60s |  15m |");
 			if(nthd != 1)
-				out.append(" ID | 10s |  60s |  15m |\n");
+				out.append(" ID |  10s |  60s |  15m |\n");
 			else
 				out.append(1, '\n');
 


### PR DESCRIPTION
Before:
<img width="457" alt="screen shot 2017-11-15 at 1 31 35 am" src="https://user-images.githubusercontent.com/1990056/32828886-3d6652de-c9a5-11e7-8113-345da3a1fdde.png">

After:
<img width="436" alt="screen shot 2017-11-15 at 1 36 02 am" src="https://user-images.githubusercontent.com/1990056/32828928-601ccb1e-c9a5-11e7-9bd5-c58b65079ae6.png">
