### PR TITLE
fix auto suggestion for low end devices 

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,4 +29,4 @@ test_script:
   - cd c:\xmr-stak\build\bin\Release
   - dir
   - copy C:\xmr-stak-dep\openssl\bin\* .
-  - xmr-stak.exe --help
+#  - xmr-stak.exe --help

--- a/xmrstak/backend/nvidia/nvcc_code/cuda_extra.cu
+++ b/xmrstak/backend/nvidia/nvcc_code/cuda_extra.cu
@@ -380,6 +380,10 @@ extern "C" int cuda_get_deviceinfo(nvid_ctx* ctx)
 		 */
 		ctx->device_blocks = props.multiProcessorCount *
 			( props.major < 3 ? 2 : 3 );
+
+		// increase bfactor for low end devices to avoid that the miner is killed by the OS
+		if(props.multiProcessorCount < 6)
+			ctx->device_bfactor += 2;
 	}
 	if(ctx->device_threads == -1)
 	{


### PR DESCRIPTION
Increase bfactor for all devices with lesser than 6 multi processors.

This PR should fix #172.

- [x] please merge after #179. Appvoyer fix is included in the first commit of the PR