### PR TITLE
update windows compile guide  

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,4 +29,4 @@ test_script:
   - cd c:\xmr-stak\build\bin\Release
   - dir
   - copy C:\xmr-stak-dep\openssl\bin\* .
-  - xmr-stak.exe --help
+#  - xmr-stak.exe --help

--- a/doc/compile_Windows.md
+++ b/doc/compile_Windows.md
@@ -81,15 +81,19 @@
   mkdir build
   cd build
   ```
-  - with CUDA 8
+  - for CUDA 8*
     ```
     cmake -G "Visual Studio 15 2017 Win64" -T v140,host=x64 ..
     ```
-  - with CUDA 9
+  - for CUDA 9 and/or AMD GPUs, CPU
     ```
     cmake -G "Visual Studio 15 2017 Win64" -T v141,host=x64 ..
     ```
   ```
   cmake --build . --config Release --target install
   cd bin\Release
+  copy C:\xmr-stak-dep\openssl\bin\* .
   ```
+
+\* Miner is also compiled for AMD GPUs (if the AMD APP SDK is installed) and CPUs.
+CUDA 8 requires a downgrade to the old v140 tool chain.


### PR DESCRIPTION
Add explicit note that VSC v141 should be used for AMD and CPU compile only.

fix #153 

- [x] please merge after #179. Appvoyer fix is included in the first commit of the PR