### PR TITLE
Add missing #include to fix compilation on macOS

### DIFF
--- a/xmrstak/backend/amd/amd_gpu/gpu.hpp
+++ b/xmrstak/backend/amd/amd_gpu/gpu.hpp
@@ -10,6 +10,7 @@
 
 #include <stdint.h>
 #include <vector>
+#include <string>
 
 #define ERR_SUCCESS (0)
 #define ERR_OCL_API (2)


### PR DESCRIPTION
#include <string>
was missing to allow compilation under macOS High Sierra.