### PR TITLE
Fix for AMD GPU detection on MacOS X

### DIFF
--- a/xmrstak/backend/amd/amd_gpu/gpu.cpp
+++ b/xmrstak/backend/amd/amd_gpu/gpu.cpp
@@ -476,7 +476,7 @@ std::vector<GpuContext> getAMDDevices(int index)
 						if(clStatus == CL_SUCCESS)
 						{
 							std::string devVendor(devVendorVec.data());
-							if( devVendor.find("Advanced Micro Devices") != std::string::npos)
+							if( devVendor.find("Advanced Micro Devices") != std::string::npos || devVendor.find("AMD") != std::string::npos)
 							{
 								GpuContext ctx;
 								ctx.deviceIdx = k;
@@ -541,7 +541,7 @@ int getAMDPlatformIdx()
 
 			clGetPlatformInfo(platforms[i], CL_PLATFORM_VENDOR, infoSize, platformNameVec.data(), NULL);
 			std::string platformName(platformNameVec.data());
-			if( platformName.find("Advanced Micro Devices") != std::string::npos)
+			if( platformName.find("Advanced Micro Devices") != std::string::npos || platformName.find("Apple") != std::string::npos)
 			{
 				platformIndex = i;
 				printer::inst()->print_msg(L0,"Found AMD platform index id = %i, name = %s",i , platformName.c_str());


### PR DESCRIPTION
Fix for AMD GPU detection on MacOS X
On MacOS X the platform is reported as Apple, and the vendor is reported as AMD.

**Output from existing code on MacOS X with AMD GPU**
[2017-11-21 12:55:03] : Start mining: MONERO
[2017-11-21 12:55:03] : WARNING: No AMD OpenCL platform found. Possible driver issues or wrong vendor driver.
[2017-11-21 12:55:03] : WARNING: backend AMD disabled.

**Output from code with fix**
[2017-11-21 12:56:56] : Start mining: MONERO
[2017-11-21 12:56:56] : Found AMD platform index id = 0, name = Apple
[2017-11-21 12:56:56] : Found OpenCL GPU AMD Radeon Pro 455 Compute Engine.
[2017-11-21 12:56:56] : AMD: GPU configuration stored in file 'amd.txt'
[2017-11-21 12:56:56] : Compiling code and initializing GPUs. This will take a while...
[2017-11-21 12:56:56] : WARNING: using non AMD device: Apple
[2017-11-21 12:56:56] : Device 1 work size 8 / 32.
[2017-11-21 12:57:00] : Starting AMD GPU thread 0, no affinity.

Please note I am not fixing the cosmetic warning about non AMD device in this commit.

**Contants of generated amd.txt file**
/*
 * GPU configuration. You should play around with intensity and worksize as the fastest settings will vary.
 *      index    - GPU index number usually starts from 0
 *  intensity    - Number of parallel GPU threads (nothing to do with CPU threads)
 *   worksize    - Number of local GPU threads (nothing to do with CPU threads)
 * affine_to_cpu - This will affine the thread to a CPU. This can make a GPU miner play along nicer with a CPU miner.
 * "gpu_threads_conf" :
 * [
 *      { "index" : 0, "intensity" : 1000, "worksize" : 8, "affine_to_cpu" : false },
 * ],
 */

"gpu_threads_conf" : [
  // gpu: AMD Radeon Pro 455 Compute Engine memory:384
  // compute units: 12
  { "index" : 1,
    "intensity" : 96, "worksize" : 8,
    "affine_to_cpu" : false,
  },

],

/*
 * Platform index. This will be 0 unless you have different OpenCL platform - eg. AMD and Intel.
 */
"platform_index" : 0,
