### PR TITLE
Add compilation instructions for MacOS

### DIFF
--- a/doc/compile.md
+++ b/doc/compile.md
@@ -9,6 +9,7 @@
 * [Compile on Windows](compile_Windows.md)
 * [Compile on Linux](compile_Linux.md)
 * [Compile on FreeBSD](compile_FreeBSD.md)
+* [Compile on MacOS](compile_MacOS.md)
 
 ## Build System
 
@@ -30,6 +31,7 @@ After the configuration you need to compile the miner, follow the guide for your
 * [Compile in Windows](compile_Windows.md)
 * [Compile in Linux](compile_Linux.md)
 * [Compile in FreeBSD](compile_FreeBSD.md)
+* [Compile in MacOS](compile_MacOS.md)
 
 ## Generic Build Options
 - `CMAKE_INSTALL_PREFIX` install miner to the home folder

--- a/doc/compile_MacOS.md
+++ b/doc/compile_MacOS.md
@@ -1,0 +1,31 @@
+# Compile **xmr-stak** for MacOS
+
+## Dependencies
+
+Assuming you already have [Homebrew](https://brew.sh) installed, the installation of dependencies is pretty straightforward and will generate the `xmr-stak` binary in the `bin/` directory.
+
+### For NVIDIA GPUs
+
+```shell
+brew tap caskroom/drivers
+brew cask install nvidia-cuda
+brew install hwloc libmicrohttpd gcc openssl cmake
+cmake . -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl -DOpenCL_ENABLE=OFF
+make install
+```
+
+[All available CMake options](compile.md#nvidia-build-options)
+
+### For AMD GPUs
+
+> 🖐 We need help with AMD GPU compilation instructions. Please submit a PR if you managed to install [AMD APP SDK](http://developer.amd.com/amd-accelerated-parallel-processing-app-sdk/) and to compile `xmr-stak` on MacOS.
+
+### For CPU-only mining
+
+```shell
+brew install hwloc libmicrohttpd gcc openssl cmake
+cmake . -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl -DCUDA_ENABLE=OFF -DOpenCL_ENABLE=OFF
+make install
+```
+
+[All available CMake options](compile.md#cpu-build-options)

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -20,7 +20,7 @@ The number of files depends on the available backends.
 1) Double click the `xmr-stak.exe` file
 2) Fill in the pool url, username and password
 
-## Usage on Linux
+## Usage on Linux & MacOS
 1) Open a terminal within the folder with the binary
 2) Start the miner with `./xmr-stak`
 


### PR DESCRIPTION
This PR is a repost of #169 with some modifications to address @psychocrypt review.

It adds compilation instructions (including dependencies installation instructions) for MacOS for either Nvidia GPUs or CPU-only mining.