### PR TITLE
Right align hashrate report to six characters

### DIFF
--- a/xmrstak/misc/executor.cpp
+++ b/xmrstak/misc/executor.cpp
@@ -625,14 +625,11 @@ inline const char* hps_format(double h, char* buf, size_t l)
 {
 	if(std::isnormal(h) || h == 0.0)
 	{
-		if(h < 10.0)
-			snprintf(buf, l, "  %03.1f", h);
-		else
-			snprintf(buf, l, " %04.1f", h);
+		snprintf(buf, l, " %6.1f", h);
 		return buf;
 	}
 	else
-		return " (na)";
+		return "   (na)";
 }
 
 bool executor::motd_filter_console(std::string& motd)
@@ -726,9 +723,9 @@ void executor::hashrate_report(std::string& out)
 			std::transform(name.begin(), name.end(), name.begin(), ::toupper);
 			
 			out.append("HASHRATE REPORT - ").append(name).append("\n");
-			out.append("| ID |  10s |  60s |  15m |");
+			out.append("| ID |    10s |    60s |    15m |");
 			if(nthd != 1)
-				out.append(" ID |  10s |  60s |  15m |\n");
+				out.append(" ID |    10s |    60s |    15m |\n");
 			else
 				out.append(1, '\n');
 


### PR DESCRIPTION
I wanted to make the hashrate report columns line up.  This is the result.  Should allow for a hashrate up to 9999.9.