### PR TITLE
fix CMake 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -361,7 +361,7 @@ if(HWLOC_ENABLE)
         PATH_SUFFIXES
             lib)
 
-    if("${HWLOC}" STREQUAL "MHTD-NOTFOUND" OR ${HWLOC_INCLUDE_DIR} STREQUAL "HWLOC_INCLUDE_DIR-NOTFOUND")
+    if("${HWLOC}" STREQUAL "HWLOC-NOTFOUND" OR ${HWLOC_INCLUDE_DIR} STREQUAL "HWLOC_INCLUDE_DIR-NOTFOUND")
         message(FATAL_ERROR "hwloc NOT found: use `-DHWLOC_ENABLE=OFF` to build without hwloc support")
     else()
         set(LIBS ${LIBS} ${HWLOC})
@@ -446,7 +446,10 @@ add_library(xmr-stak-c
     ${SRCFILES_C}
 )
 set_property(TARGET xmr-stak-c PROPERTY C_STANDARD 99)
-target_link_libraries(xmr-stak-c ${MHTD} ${LIBS})
+if(MICROHTTPD_ENABLE)
+    target_link_libraries(xmr-stak-c ${MHTD})
+endif()
+target_link_libraries(xmr-stak-c ${LIBS})
 
 # compile generic backend files
 file(GLOB BACKEND_CPP

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(xmr-stak)
 
-cmake_minimum_required(VERSION 3.0.1)
+cmake_minimum_required(VERSION 3.1.0)
 
 # enforce C++11
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -42,23 +42,23 @@ set_property(CACHE XMR-STAK_CURRENCY PROPERTY STRINGS "all;monero;aeon")
 
 set(XMR-STAK_COMPILE "native" CACHE STRING "select CPU compute architecture")
 set_property(CACHE XMR-STAK_COMPILE PROPERTY STRINGS "native;generic")
-if("${XMR-STAK_COMPILE}" STREQUAL "native")
+if(XMR-STAK_COMPILE STREQUAL "native")
     if(NOT CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
         set(CMAKE_CXX_FLAGS "-march=native -mtune=native ${CMAKE_CXX_FLAGS}")
         set(CMAKE_C_FLAGS "-march=native -mtune=native ${CMAKE_C_FLAGS}")
     endif()
-elseif("${XMR-STAK_COMPILE}" STREQUAL "generic")
+elseif(XMR-STAK_COMPILE STREQUAL "generic")
     add_definitions("-DCONF_ENFORCE_OpenCL_1_2=1")
 else()
     message(FATAL_ERROR "XMR-STAK_COMPILE is set to an unknown value '${XMR-STAK_COMPILE}'")
 endif()
 
-if("${XMR-STAK_CURRENCY}" STREQUAL "all")
+if(XMR-STAK_CURRENCY STREQUAL "all")
     message(STATUS "Set miner currency to 'monero' and 'aeon'")
-elseif("${XMR-STAK_CURRENCY}" STREQUAL "aeon")
+elseif(XMR-STAK_CURRENCY STREQUAL "aeon")
     message(STATUS "Set miner currency to 'aeon'")
     add_definitions("-DCONF_NO_MONERO=1")
-elseif("${XMR-STAK_CURRENCY}" STREQUAL "monero")
+elseif(XMR-STAK_CURRENCY STREQUAL "monero")
     message(STATUS "Set miner currency to 'monero'")
     add_definitions("-DCONF_NO_AEON=1")
 endif()
@@ -134,7 +134,7 @@ if(CUDA_ENABLE)
         option(CUDA_SHOW_REGISTER "Show registers used for each kernel and compute architecture" OFF)
         option(CUDA_KEEP_FILES "Keep all intermediate files that are generated during internal compilation steps" OFF)
 
-        if("${CUDA_COMPILER}" STREQUAL "clang")
+        if(CUDA_COMPILER STREQUAL "clang")
             set(CLANG_BUILD_FLAGS "-O3 -x cuda --cuda-path=${CUDA_TOOLKIT_ROOT_DIR}")
             # activation usage of FMA
             set(CLANG_BUILD_FLAGS "${CLANG_BUILD_FLAGS} -ffp-contract=fast")
@@ -152,9 +152,9 @@ if(CUDA_ENABLE)
                 set(CLANG_BUILD_FLAGS "${CLANG_BUILD_FLAGS} --cuda-gpu-arch=sm_${CUDA_ARCH_ELEM}")
             endforeach()
 
-        elseif("${CUDA_COMPILER}" STREQUAL "nvcc")
+        elseif(CUDA_COMPILER STREQUAL "nvcc")
             # add c++11 for cuda
-            if(NOT "${CMAKE_CXX_FLAGS}" MATCHES "-std=c\\+\\+11")
+            if(NOT CMAKE_CXX_FLAGS MATCHES "-std=c\\+\\+11")
                 set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -std=c++11")
             endif()
 
@@ -307,7 +307,7 @@ if(MICROHTTPD_ENABLE)
             ENV "MICROHTTPD_ROOT"
         PATH_SUFFIXES
             lib)
-    if("${MHTD}" STREQUAL "MHTD-NOTFOUND")
+    if(MHTD STREQUAL "MHTD-NOTFOUND")
         message(FATAL_ERROR "microhttpd NOT found: use `-DMICROHTTPD_ENABLE=OFF` to build without http deamon support")
     else()
         set(LIBS ${LIBS} ${MHTD})
@@ -361,7 +361,7 @@ if(HWLOC_ENABLE)
         PATH_SUFFIXES
             lib)
 
-    if("${HWLOC}" STREQUAL "HWLOC-NOTFOUND" OR ${HWLOC_INCLUDE_DIR} STREQUAL "HWLOC_INCLUDE_DIR-NOTFOUND")
+    if(HWLOC STREQUAL "HWLOC-NOTFOUND" OR ${HWLOC_INCLUDE_DIR} STREQUAL "HWLOC_INCLUDE_DIR-NOTFOUND")
         message(FATAL_ERROR "hwloc NOT found: use `-DHWLOC_ENABLE=OFF` to build without hwloc support")
     else()
         set(LIBS ${LIBS} ${HWLOC})
@@ -399,10 +399,10 @@ execute_process(
   OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 
-if(NOT "${GIT_COMMIT_HASH}" STREQUAL "")
+if(NOT GIT_COMMIT_HASH STREQUAL "")
 	add_definitions("-DGIT_COMMIT_HASH=${GIT_COMMIT_HASH}")
 endif()
-if(NOT "${GIT_BRANCH}" STREQUAL "")
+if(NOT GIT_BRANCH STREQUAL "")
 	add_definitions("-DGIT_BRANCH=${GIT_BRANCH}")
 endif()
 
@@ -473,7 +473,7 @@ if(CUDA_FOUND)
         "xmrstak/backend/nvidia/nvcc_code/*.cu"
         "xmrstak/backend/nvidia/*.cpp")
 
-    if("${CUDA_COMPILER}" STREQUAL "clang")
+    if(CUDA_COMPILER STREQUAL "clang")
         # build device code with clang
         add_library(
             xmrstak_cuda_backend
@@ -533,7 +533,7 @@ endif()
 
 
 # do not install the binary if the project and install are equal
-if( NOT "${CMAKE_INSTALL_PREFIX}" STREQUAL "${PROJECT_BINARY_DIR}" )
+if( NOT CMAKE_INSTALL_PREFIX STREQUAL PROJECT_BINARY_DIR )
     install(TARGETS xmr-stak
             RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}/bin")
     if(CUDA_FOUND)


### PR DESCRIPTION
- fix wrong compare for HWLOC not found
- remove usage of microhttpd variable if microhttpd is disabled
- remove all `"${VARNAME}` usages in if conditions
- increase cmake minimum version to 3.1 to have the new behavior of [CMP0054](https://cmake.org/cmake/help/v3.1/policy/CMP0054.html)