### PR TITLE
Add macOS CPU-only build instructions

### DIFF
--- a/doc/compile.md
+++ b/doc/compile.md
@@ -30,6 +30,7 @@ After the configuration you need to compile the miner, follow the guide for your
 * [Compile in Windows](compile_Windows.md)
 * [Compile in Linux](compile_Linux.md)
 * [Compile in FreeBSD](compile_FreeBSD.md)
+* [Compile in maxOS](compile_macOS.md)
 
 ## Generic Build Options
 - `CMAKE_INSTALL_PREFIX` install miner to the home folder

--- a/doc/compile_macOS.md
+++ b/doc/compile_macOS.md
@@ -1,0 +1,19 @@
+# Compile **xmr-stak** for macOS (CPU only)
+
+This may be useful for experimenting with this miner or testing pool configurations. You will most likely want to mine on a machine with a GPU.
+
+## Install Dependencies
+
+Requires [Homebrew](https://brew.sh/)
+
+```bash
+brew install cmake hwloc libmicrohttpd
+```
+
+## Build
+
+```bash
+cmake . -DCPU_ENABLE=ON -DHWLOC_ENABLE=ON -DCUDA_ENABLE=OFF -DOpenCL_ENABLE=OFF
+```
+
+This will build a binary to `./bin/xmr-stak`.


### PR DESCRIPTION
The process is pretty simple, but it's worth noting down for future
visitors to the project. I tested it on a 2017 Macbook Pro. I didn't
include OpenCL/AMD instructions as I have no way of testing them.
Whoever wants to start mining on a new iMac Pro can add those instead ;)