### PR TITLE
allow to diable UAC dialog

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -22,7 +22,7 @@ build_script:
   - mkdir build
   - cd build
   - set CMAKE_PREFIX_PATH=C:\xmr-stak-dep\hwloc;C:\xmr-stak-dep\libmicrohttpd;C:\xmr-stak-dep\openssl;
-  - cmake -G "Visual Studio 14 2015 Win64" -T v140,host=x64 .. -DWIN_UAC=OFF -DCUDA_ARCH=30
+  - cmake -G "Visual Studio 14 2015 Win64" -T v140,host=x64 .. -DCUDA_ARCH=30
   - cmake --build . --config Release --target install
 
 test_script:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -521,12 +521,6 @@ set(LIBRARY_OUTPUT_PATH "bin")
 
 target_link_libraries(xmr-stak ${LIBS} xmr-stak-c xmr-stak-backend)
 
-option(WIN_UAC "Add UAC manifest on Windows" ON)
-
-if(WIN_UAC AND CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
-    set_property(TARGET xmr-stak PROPERTY LINK_FLAGS "/level='requireAdministrator' /uiAccess='false'")
-endif()
-
 ################################################################################
 # Install
 ################################################################################

--- a/doc/compile.md
+++ b/doc/compile.md
@@ -52,11 +52,6 @@ After the configuration you need to compile the miner, follow the guide for your
   - native means the miner binary can be used only on the system where it is compiled but will archive the highest hash rate
   - use `cmake .. -DXMR-STAK_COMPILE=generic` to run the miner on all CPU's with sse2
 
-### only available for Windows
-- `WIN_UAC` will enable or disable the "Run As Administrator" prompt on Windows.
-  - UAC confirmation is needed to use large pages on Windows 7.
-  - On Windows 10 it is only needed once to set up the account to use them.
-
 ## CPU Build Options
 
 - `CPU_ENABLE` allow to disable/enable the CPU backend of the miner

--- a/doc/tuning.md
+++ b/doc/tuning.md
@@ -1,6 +1,7 @@
 # Tuning Guide
 
 ## Content Overview
+* [Windows](windows)
 * [NVIDIA Backend](#nvidia-backend)
   * [Choose Value for `threads` and `blocks`](#choose-value-for-threads-and-blocks)
   * [Add more GPUs](#add-more-gpus)
@@ -9,6 +10,11 @@
   * [Add more GPUs](#add-more-gpus)
   * [Increase Memory Pool](#increase-memory-pool)
   * [Scratchpad Indexing](#scratchpad-indexing)
+
+## Windows
+"Run As Administrator" prompt (UAC) confirmation is needed to use large pages on Windows 7.
+On Windows 10 it is only needed once to set up the account to use them.
+Disable the dialog with the command line option `--noUAC`
 
 ## NVIDIA Backend
 

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -30,27 +30,7 @@ The number of files depends on the available backends.
 ## Command Line Options
 
 The miner allow to overwrite some of the settings via command line options.
-
-```
-Usage: xmr-stak [OPTION]...
-
-  -h, --help            show this help
-  -v, --version         show version number
-  -V, --version-long  show long version number
-  -c, --config FILE     common miner configuration file
-  --currency NAME       currency to mine: monero or aeon
-  --noCPU               disable the CPU miner backend
-  --cpu FILE            CPU backend miner config file
-  --noAMD               disable the AMD miner backend
-  --amd FILE            AMD backend miner config file
-  --noNVIDIA            disable the NVIDIA miner backend
-  --nvidia FILE         NVIDIA backend miner config file
-
-The Following options temporary overwrites the config file settings:
-  -o, --url URL         pool url and port, e.g. pool.usxmrpool.com:3333
-  -u, --user USERNAME   pool user name or wallet address
-  -p, --pass PASSWD     pool password, in the most cases x or empty ""
-```
+Run `xmr-stak --help` to show all available command line options.
 
 ## Docker image usage
 

--- a/xmrstak/cli/cli-miner.cpp
+++ b/xmrstak/cli/cli-miner.cpp
@@ -280,8 +280,9 @@ void do_guided_config(bool userSetPasswd)
  *   - author: Cody Gray
  *   - date: Feb 4 '11
  */
-void UACDialog(const std::string& binaryName, const std::string& args)
+void UACDialog(const std::string& binaryName, std::string& args)
 {
+		args += " --noUAC";
 		SHELLEXECUTEINFO shExInfo = {0};
 		shExInfo.cbSize = sizeof(shExInfo);
 		shExInfo.fMask = SEE_MASK_NOCLOSEPROCESS;
@@ -289,11 +290,11 @@ void UACDialog(const std::string& binaryName, const std::string& args)
 		shExInfo.lpVerb = "runas";     
 		shExInfo.lpFile = binaryName.c_str();
 		// disable UAC dialog (else the miner will go into a infinite loop)
-		shExInfo.lpParameters = (args + " --noUAC").c_str();
+		shExInfo.lpParameters = args.c_str();
 		shExInfo.lpDirectory = 0;
 		shExInfo.nShow = SW_SHOW;
 		shExInfo.hInstApp = 0;
-
+		
 		if(ShellExecuteEx(&shExInfo))
 		{
 			WaitForSingleObject(shExInfo.hProcess, INFINITE);
@@ -477,7 +478,11 @@ int main(int argc, char *argv[])
 	{
 		std::string minerArgs;
 		for(int i = 1; i < argc; i++)
-			minerArgs += std::string(" ") + argv[i];
+		{
+			minerArgs += " ";
+			minerArgs += argv[i];
+		}
+
 		UACDialog(argv[0], minerArgs);
 	}
 #endif

--- a/xmrstak/cli/cli-miner.cpp
+++ b/xmrstak/cli/cli-miner.cpp
@@ -297,6 +297,8 @@ void UACDialog(const std::string& binaryName, std::string& args)
 		
 		if(ShellExecuteEx(&shExInfo))
 		{
+			printer::inst()->print_msg(L0,
+				"This window has been opened because xmr-stak needed to run as administrator.  It can be safely closed now.");
 			WaitForSingleObject(shExInfo.hProcess, INFINITE);
 			CloseHandle(shExInfo.hProcess);
 			// do not start the miner twice

--- a/xmrstak/cli/cli-miner.cpp
+++ b/xmrstak/cli/cli-miner.cpp
@@ -66,6 +66,9 @@ void help()
 	cout<<"  -v, --version         show version number"<<endl;
 	cout<<"  -V, --version-long    show long version number"<<endl;
 	cout<<"  -c, --config FILE     common miner configuration file"<<endl;
+#ifdef _WIN32
+	cout<<"  --noUAC               disable the UAC dialog"<<endl;
+#endif
 #if (!defined(CONF_NO_AEON)) && (!defined(CONF_NO_MONERO))
 	cout<<"  --currency NAME       currency to mine: monero or aeon"<<endl;
 #endif
@@ -269,6 +272,38 @@ void do_guided_config(bool userSetPasswd)
 	std::cout<<"Configuration stored in file '"<<params::inst().configFile<<"'"<<std::endl;
 }
 
+#ifdef _WIN32
+/** start the miner as administrator
+ *
+ * This function based on the stackoverflow post
+ *   - source: https://stackoverflow.com/a/4893508
+ *   - author: Cody Gray
+ *   - date: Feb 4 '11
+ */
+void UACDialog(std::string binaryName)
+{
+		SHELLEXECUTEINFO shExInfo = {0};
+		shExInfo.cbSize = sizeof(shExInfo);
+		shExInfo.fMask = SEE_MASK_NOCLOSEPROCESS;
+		shExInfo.hwnd = 0;
+		shExInfo.lpVerb = "runas";     
+		shExInfo.lpFile = binaryName.c_str();
+		// disable UAC dialog (else the miner will go into a infinite loop)
+		shExInfo.lpParameters = "--noUAC"; 
+		shExInfo.lpDirectory = 0;
+		shExInfo.nShow = SW_SHOW;
+		shExInfo.hInstApp = 0;
+
+		if(ShellExecuteEx(&shExInfo))
+		{
+			WaitForSingleObject(shExInfo.hProcess, INFINITE);
+			CloseHandle(shExInfo.hProcess);
+			// do not start the miner twice
+			std::exit(0);
+		}
+}
+#endif
+
 int main(int argc, char *argv[])
 {
 #ifndef CONF_NO_TLS
@@ -302,6 +337,7 @@ int main(int argc, char *argv[])
 	}
 
 	bool userSetPasswd = false;
+	bool uacDialog = true;
 	for(int i = 1; i < argc; ++i)
 	{
 		std::string opName(argv[i]);
@@ -424,6 +460,10 @@ int main(int argc, char *argv[])
 			}
 			params::inst().configFile = argv[i];
 		}
+		else if(opName.compare("--noUAC") == 0)
+		{
+			uacDialog = false;
+		}
 		else
 		{
 			printer::inst()->print_msg(L0, "Parameter unknown '%s'",argv[i]);
@@ -432,6 +472,11 @@ int main(int argc, char *argv[])
 		}
 	}
 
+#ifdef _WIN32
+	if(uacDialog)
+		UACDialog(argv[0]);
+#endif
+	
 	// check if we need a guided start
 	if(!configEditor::file_exist(params::inst().configFile))
 		do_guided_config(userSetPasswd);

--- a/xmrstak/cli/cli-miner.cpp
+++ b/xmrstak/cli/cli-miner.cpp
@@ -280,7 +280,7 @@ void do_guided_config(bool userSetPasswd)
  *   - author: Cody Gray
  *   - date: Feb 4 '11
  */
-void UACDialog(std::string binaryName)
+void UACDialog(const std::string& binaryName, const std::string& args)
 {
 		SHELLEXECUTEINFO shExInfo = {0};
 		shExInfo.cbSize = sizeof(shExInfo);
@@ -289,7 +289,7 @@ void UACDialog(std::string binaryName)
 		shExInfo.lpVerb = "runas";     
 		shExInfo.lpFile = binaryName.c_str();
 		// disable UAC dialog (else the miner will go into a infinite loop)
-		shExInfo.lpParameters = "--noUAC"; 
+		shExInfo.lpParameters = (args + " --noUAC").c_str();
 		shExInfo.lpDirectory = 0;
 		shExInfo.nShow = SW_SHOW;
 		shExInfo.hInstApp = 0;
@@ -474,7 +474,12 @@ int main(int argc, char *argv[])
 
 #ifdef _WIN32
 	if(uacDialog)
-		UACDialog(argv[0]);
+	{
+		std::string minerArgs;
+		for(int i = 1; i < argc; i++)
+			minerArgs += std::string(" ") + argv[i];
+		UACDialog(argv[0], minerArgs);
+	}
 #endif
 	
 	// check if we need a guided start


### PR DESCRIPTION
- remove CMake option `WIN_UAC`
- spawn UAC dialog via restarting xmr-miner with administrator right
- allow to disable UAC with `--noUAC`
- update documentation
- remove usage section with help message (output depends on OS)