### PR TITLE
add environment variable `XMRSTAK_NOWIT`

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -20,6 +20,9 @@ The number of files depends on the available backends.
 1) Double click the `xmr-stak.exe` file
 2) Fill in the pool url, username and password
 
+`set XMRSTAK_NOWAIT=1` disable the dialog `Press any key to exit.` for non UAC execution.
+
+
 ## Usage on Linux & MacOS
 1) Open a terminal within the folder with the binary
 2) Start the miner with `./xmr-stak`

--- a/xmrstak/cli/cli-miner.cpp
+++ b/xmrstak/cli/cli-miner.cpp
@@ -87,6 +87,12 @@ void help()
 	cout<<"  -u, --user USERNAME   pool user name or wallet address"<<endl;
 	cout<<"  -p, --pass PASSWD     pool password, in the most cases x or empty \"\""<<endl;
 	cout<<" \n"<<endl;
+#ifdef _WIN32
+	cout<<"Environment variables:\n"<<endl;
+	cout<<"  XMRSTAK_NOWAIT        disable the dialog `Press any key to exit."<<std::endl;
+	cout<<"                	       for non UAC execution"<<endl;
+	cout<<" \n"<<endl;
+#endif
 	cout<< "Version: " << get_version_str_short() << endl;
 	cout<<"Brought to by fireice_uk and psychocrypt under GPLv3."<<endl;
 }

--- a/xmrstak/misc/console.cpp
+++ b/xmrstak/misc/console.cpp
@@ -222,8 +222,13 @@ void printer::print_str(const char* str)
 #ifdef _WIN32
 void win_exit(size_t code)
 {
-	printer::inst()->print_str("Press any key to exit.");
-	get_key();
+	size_t envSize = 0;
+	getenv_s(&envSize, nullptr, 0, "XMRSTAK_NOWAIT");
+	if(envSize == 0)
+	{
+		printer::inst()->print_str("Press any key to exit.");
+		get_key();
+	}
 	std::exit(code);
 }
 


### PR DESCRIPTION
- add documentation
- add environment variable `XMRSTAK_NOWAIT` to disable the dialog `Press any key` on windows.

After this PR and #305 is merged we can activate the appvoyer binary test again if we set the environment variable.