### PR TITLE
optimize aes round command queue

### DIFF
--- a/xmrstak/backend/amd/amd_gpu/opencl/wolf-aes.cl
+++ b/xmrstak/backend/amd/amd_gpu/opencl/wolf-aes.cl
@@ -74,15 +74,29 @@ static const __constant uint AES0_C[256] =
 
 #define BYTE(x, y)	(amd_bfe((x), (y) << 3U, 8U))
 
-uint4 AES_Round(const __local uint *AES0, const __local uint *AES1, const __local uint *AES2, const __local uint *AES3, const uint4 X, const uint4 key)
+uint4 AES_Round(const __local uint *AES0, const __local uint *AES1, const __local uint *AES2, const __local uint *AES3, const uint4 X, uint4 key)
 {
-	uint4 Y;
-	Y.s0 = AES0[BYTE(X.s0, 0)] ^ AES1[BYTE(X.s1, 1)] ^ AES2[BYTE(X.s2, 2)] ^ AES3[BYTE(X.s3, 3)];
-    Y.s1 = AES0[BYTE(X.s1, 0)] ^ AES1[BYTE(X.s2, 1)] ^ AES2[BYTE(X.s3, 2)] ^ AES3[BYTE(X.s0, 3)];
-    Y.s2 = AES0[BYTE(X.s2, 0)] ^ AES1[BYTE(X.s3, 1)] ^ AES2[BYTE(X.s0, 2)] ^ AES3[BYTE(X.s1, 3)];
-    Y.s3 = AES0[BYTE(X.s3, 0)] ^ AES1[BYTE(X.s0, 1)] ^ AES2[BYTE(X.s1, 2)] ^ AES3[BYTE(X.s2, 3)];
-    Y ^= key;
-    return(Y);
+	key.s0 ^= AES0[BYTE(X.s0, 0)];
+    key.s1 ^= AES0[BYTE(X.s1, 0)];
+    key.s2 ^= AES0[BYTE(X.s2, 0)];
+    key.s3 ^= AES0[BYTE(X.s3, 0)];
+
+	key.s0 ^= AES2[BYTE(X.s2, 2)];
+    key.s1 ^= AES2[BYTE(X.s3, 2)];
+    key.s2 ^= AES2[BYTE(X.s0, 2)];
+    key.s3 ^= AES2[BYTE(X.s1, 2)];
+
+	key.s0 ^= AES1[BYTE(X.s1, 1)];
+    key.s1 ^= AES1[BYTE(X.s2, 1)];
+    key.s2 ^= AES1[BYTE(X.s3, 1)];
+    key.s3 ^= AES1[BYTE(X.s0, 1)];
+
+	key.s0 ^= AES3[BYTE(X.s3, 3)];
+    key.s1 ^= AES3[BYTE(X.s0, 3)];
+    key.s2 ^= AES3[BYTE(X.s1, 3)];
+    key.s3 ^= AES3[BYTE(X.s2, 3)];
+
+    return key;
 }
 
 #endif


### PR DESCRIPTION
Unroll AES round by hand to help the compiler to optimize the command queue.
This pull request will should improve the hash rate by a few hashes.


# Testes

- [x] runtime test on NVIDIA GPU with OpenCL