### PR TITLE
fix broken pool option overwrite via CLI

### DIFF
--- a/xmrstak/cli/cli-miner.cpp
+++ b/xmrstak/cli/cli-miner.cpp
@@ -82,7 +82,7 @@ void help()
 	cout<<"  --nvidia FILE         NVIDIA backend miner config file"<<endl;
 #endif
 	cout<<" "<<endl;
-	cout<<"The Following options temporary overwrites the config file settings:"<<endl;
+	cout<<"The Following options temporary overwrites the config entries of \nthe pool with the highest weight:"<<endl;
 	cout<<"  -o, --url URL         pool url and port, e.g. pool.usxmrpool.com:3333"<<endl;
 	cout<<"  -u, --user USERNAME   pool user name or wallet address"<<endl;
 	cout<<"  -p, --pass PASSWD     pool password, in the most cases x or empty \"\""<<endl;

--- a/xmrstak/misc/executor.cpp
+++ b/xmrstak/misc/executor.cpp
@@ -528,6 +528,30 @@ void executor::ex_main()
 			pools.emplace_front(0, "donate.xmr-stak.net:4444", "", "", 0.0, true, false, "", true);
 	}
 
+	/* find the pool with the highest weighting to allow overwriting of the
+	 * pool settings via command line options.
+	 */
+	std::vector<jpsock*> sorted_pools;
+	sorted_pools.reserve(pools.size());
+	for(jpsock& pool : pools)
+		sorted_pools.emplace_back(&pool);
+	std::sort(sorted_pools.begin(), sorted_pools.end(), [](jpsock* a, jpsock* b) { return b->get_pool_weight(true) < a->get_pool_weight(true); });
+
+ 	// overwrite pool address if cli option is used
+	auto& poolURL = xmrstak::params::inst().poolURL;	
+	if(!poolURL.empty())
+	{
+		sorted_pools[0]->set_pool_addr(poolURL.c_str());
+	}
+	// overwrite user pool login name if cli option is used
+	auto& poolUsername = xmrstak::params::inst().poolUsername;
+	if(!poolUsername.empty())
+		sorted_pools[0]->set_user_login(poolUsername.c_str());
+	// overwrite user pool login password if cli option is used
+	auto& poolPasswd = xmrstak::params::inst().poolPasswd;
+	if(!poolPasswd.empty())
+		sorted_pools[0]->set_user_passwd(poolPasswd.c_str());
+
 	ex_event ev;
 	std::thread clock_thd(&executor::ex_clock_thd, this);
 

--- a/xmrstak/net/jpsock.hpp
+++ b/xmrstak/net/jpsock.hpp
@@ -59,6 +59,10 @@ public:
 	inline const char* get_tls_fp() { return tls_fp.c_str(); }
 	inline bool is_nicehash() { return nicehash; }
 
+	inline void set_pool_addr(const char* sAddr) { net_addr = sAddr; }
+	inline void set_user_login(const char* sLogin) { usr_login = sLogin; }
+	inline void set_user_passwd(const char* sPassword) { usr_pass = sPassword; }
+
 	bool get_pool_motd(std::string& strin);
 
 	std::string&& get_call_error();


### PR DESCRIPTION
fix #340

With #90 the option to overwrite the pool settings via CLI options is broken.

This pull request will allow to overwrite the options of the pool with the highest weighting.