### PR TITLE
Add missing string includes for OSX

### DIFF
--- a/xmrstak/backend/amd/amd_gpu/gpu.hpp
+++ b/xmrstak/backend/amd/amd_gpu/gpu.hpp
@@ -4,6 +4,9 @@
 
 #if defined(__APPLE__)
 #include <OpenCL/cl.h>
+#include <string>
+#include <sstream>
+#include <iostream>
 #else
 #include <CL/cl.h>
 #endif


### PR DESCRIPTION
I noticed I couldn't compile the miner on MacOS X due to the following reason:

```
In file included from ~/xmr-stak/xmrstak/backend/amd/minethd.cpp:24:
In file included from ~/xmr-stak/xmrstak/backend/amd/minethd.hpp:3:
~/xmr-stak/xmrstak/backend/amd/amd_gpu/gpu.hpp:37:14: error: implicit instantiation of undefined template 'std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >'
        std::string name;
                    ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/iosfwd:193:32: note: template is declared here
    class _LIBCPP_TEMPLATE_VIS basic_string;
                               ^
1 error generated.
make[2]: *** [CMakeFiles/xmrstak_opencl_backend.dir/xmrstak/backend/amd/minethd.cpp.o] Error 1
make[1]: *** [CMakeFiles/xmrstak_opencl_backend.dir/all] Error 2
make: *** [all] Error 2
```
On [StackOverflow](https://stackoverflow.com/a/19836469/5094336) I found that some string and stream includes were missing. Adding them made the miner compile flawlessly.