### PR TITLE
CMake: fix wrong variable name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -348,7 +348,7 @@ if(HWLOC_ENABLE)
             /usr/local
             /usr
             ENV "PROGRAMFILES(X86)"
-            ENV "MICROHTTPD_ROOT"
+            ENV "HWLOC_ROOT"
         PATH_SUFFIXES
             include)
 


### PR DESCRIPTION
change `MICROHTTPD_ROOT` to `HWLOC_ROOT` within the hwlock section

thx @maztheman for spotting the bug