### PR TITLE
Fix compat_usleep for WIN32

### DIFF
--- a/xmrstak/backend/nvidia/nvcc_code/cuda_core.cu
+++ b/xmrstak/backend/nvidia/nvcc_code/cuda_core.cu
@@ -19,7 +19,7 @@ extern "C" void compat_usleep(uint64_t waitTime)
             HANDLE timer;
             LARGE_INTEGER ft;
 
-            ft.QuadPart = -10*(LONGLONG)waitTime; // Convert to 100 nanosecond interval, negative value indicates relative time
+            ft.QuadPart = -10ll * int64_t(waitTime); // Convert to 100 nanosecond interval, negative value indicates relative time
 
             timer = CreateWaitableTimer(NULL, TRUE, NULL);
             SetWaitableTimer(timer, &ft, 0, NULL, NULL, 0);

--- a/xmrstak/backend/nvidia/nvcc_code/cuda_core.cu
+++ b/xmrstak/backend/nvidia/nvcc_code/cuda_core.cu
@@ -19,7 +19,7 @@ extern "C" void compat_usleep(uint64_t waitTime)
             HANDLE timer;
             LARGE_INTEGER ft;
 
-            ft.QuadPart = -(10*waitTime); // Convert to 100 nanosecond interval, negative value indicates relative time
+            ft.QuadPart = -10*(LONGLONG)waitTime; // Convert to 100 nanosecond interval, negative value indicates relative time
 
             timer = CreateWaitableTimer(NULL, TRUE, NULL);
             SetWaitableTimer(timer, &ft, 0, NULL, NULL, 0);


### PR DESCRIPTION
When compiled with VS2017, the negative applied to the uint wait time is ignored. Fixed by casting first.

This has vastly improved stability on my Windows 10 setup and has increased performance significantly.