### PR TITLE
Also fflush in printer::print_str() if configured to do so

### DIFF
--- a/xmrstak/misc/console.cpp
+++ b/xmrstak/misc/console.cpp
@@ -211,6 +211,11 @@ void printer::print_str(const char* str)
 	std::unique_lock<std::mutex> lck(print_mutex);
 	fputs(str, stdout);
 
+	if (b_flush_stdout)
+	{
+		fflush(stdout);
+	}
+
 	if(logfile != nullptr)
 	{
 		fputs(str, logfile);


### PR DESCRIPTION
Honor the config file's flush_stdout setting when printing reports.