### PR TITLE
fix cuda9.1 compile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,7 +108,11 @@ if(CUDA_ENABLE)
         endif()
         # add Volta support for CUDA >= 9.0
         if(NOT CUDA_VERSION VERSION_LESS 9.0)
-            list(APPEND DEFAULT_CUDA_ARCH "70")
+            # Volta GPUs are currently not supported on MACOSX
+            # https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html#cuda-general-known-issues
+            if(NOT APPLE)
+                list(APPEND DEFAULT_CUDA_ARCH "70")
+            endif()
         endif()
         set(CUDA_ARCH "${DEFAULT_CUDA_ARCH}" CACHE STRING "Set GPU architecture (semicolon separated list, e.g. '-DCUDA_ARCH=20;35;60')")
 

--- a/xmrstak/backend/nvidia/nvcc_code/cuda_extra.cu
+++ b/xmrstak/backend/nvidia/nvcc_code/cuda_extra.cu
@@ -6,7 +6,6 @@
 #include <vector>
 #include <cuda.h>
 #include <cuda_runtime.h>
-#include <device_functions.hpp>
 #include  <algorithm>
 #include "xmrstak/jconf.hpp"
 


### PR DESCRIPTION
- fix cuda9.1 compile (remove include of device_functions.hpp/ removed with cuda9.1)
- remove NVIDIA Volta gpus for MAC OSX (https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html#cuda-general-known-issues)

should solve #473 #492 #530 #287