### PR TITLE
for CentOS, do scl without sudo

### DIFF
--- a/doc/compile_Linux.md
+++ b/doc/compile_Linux.md
@@ -43,7 +43,7 @@
     # CentOS
     sudo yum install centos-release-scl epel-release
     sudo yum install cmake3 devtoolset-4-gcc* hwloc-devel libmicrohttpd-devel openssl-devel make
-    sudo scl enable devtoolset-4 bash
+    scl enable devtoolset-4 bash
     git clone https://github.com/fireice-uk/xmr-stak.git
     mkdir xmr-stak/build
     cd xmr-stak/build


### PR DESCRIPTION
I ran into a problem following these instructions, and this change got me past it.

The command in question enables access to the C++ compiler (puts it on the PATH or something like that).  If you do it with `sudo`, it leaves you at a root shell prompt.  If you then exit that root prompt, to go back to non-root, then g++ is no longer accessible.  If you want to compile as non-root, then you need to do `scl` as non-root.