### PR TITLE
Fix CUDA 9.1 compatibility issue

### DIFF
--- a/xmrstak/backend/nvidia/nvcc_code/cuda_extra.cu
+++ b/xmrstak/backend/nvidia/nvcc_code/cuda_extra.cu
@@ -6,7 +6,7 @@
 #include <vector>
 #include <cuda.h>
 #include <cuda_runtime.h>
-#include <device_functions.hpp>
+#include <device_functions.h>
 #include  <algorithm>
 #include "xmrstak/jconf.hpp"
 


### PR DESCRIPTION
This fixes the `fatal error: device_functions.hpp: "No such file or directory" <device_functions.hpp>` issue when compiling on Ubuntu. 

It seems related to the new CUDA version.

Let me know if there's need to first open an issue or something like this.