### PR TITLE
increase version to 2.2.0

### DIFF
--- a/xmrstak/version.cpp
+++ b/xmrstak/version.cpp
@@ -18,7 +18,7 @@
 #endif
 
 #define XMR_STAK_NAME "xmr-stak"
-#define XMR_STAK_VERSION "2.1.0"
+#define XMR_STAK_VERSION "2.2.0"
 
 #if defined(_WIN32)
 #define OS_TYPE "win"


### PR DESCRIPTION
Increase version for a bug fix release. ~~Because of the reason we have only fixed bugs I increased only the bug fix number in the version.~~
update: @taisel released a xmr-stak version https://www.reddit.com/r/MoneroMining/comments/7lfj4d/updated_the_xmrstak_fork/?ref=share&ref_source=link under a version number which conflicts with our versioning order. For the user it looks like the fork is newer than our next release. This is not the case therefore we need to increase the second number instead the third.