### PR TITLE
[WIP] add new option `extra_intensity`

### DIFF
--- a/xmrstak/backend/amd/amd_gpu/gpu.hpp
+++ b/xmrstak/backend/amd/amd_gpu/gpu.hpp
@@ -5,7 +5,7 @@
 #if defined(__APPLE__)
 #include <OpenCL/cl.h>
 #else
-#include <CL/cl.h>
+#include <CL/cl_ext.h>
 #endif
 
 #include <stdint.h>
@@ -23,6 +23,7 @@ struct GpuContext
 	/*Input vars*/
 	size_t deviceIdx;
 	size_t rawIntensity;
+	size_t rawExtraIntensity;
 	size_t workSize;
 	int stridedIndex;
 
@@ -31,7 +32,7 @@ struct GpuContext
 	cl_command_queue CommandQueues;
 	cl_mem InputBuffer;
 	cl_mem OutputBuffer;
-	cl_mem ExtraBuffers[6];
+	cl_mem ExtraBuffers[7];
 	cl_program Program;
 	cl_kernel Kernels[7];
 	size_t freeMem;

--- a/xmrstak/backend/amd/autoAdjust.hpp
+++ b/xmrstak/backend/amd/autoAdjust.hpp
@@ -21,7 +21,7 @@
 #if defined(__APPLE__)
 #include <OpenCL/cl.h>
 #else
-#include <CL/cl.h>
+#include <CL/cl_ext.h>
 #endif
 
 
@@ -122,7 +122,8 @@ private:
 			conf += std::string("  // compute units: ") + std::to_string(ctx.computeUnits) + "\n";
 			// set 8 threads per block (this is a good value for the most gpus)
 			conf += std::string("  { \"index\" : ") + std::to_string(ctx.deviceIdx) + ",\n" +
-				"    \"intensity\" : " + std::to_string(intensity) + ", \"worksize\" : " + std::to_string(8) + ",\n" +
+				"    \"intensity\" : " + std::to_string(intensity) + ", \"extra_intensity\" : 0,\n"
+			    "    \"worksize\" : " + std::to_string(8) + ",\n" +
 				"    \"affine_to_cpu\" : false, \"strided_index\" : true\n"
 				"  },\n";
 			++i;

--- a/xmrstak/backend/amd/config.tpl
+++ b/xmrstak/backend/amd/config.tpl
@@ -10,7 +10,7 @@ R"===(
  *                 false = use a contiguous block of memory per thread
  * "gpu_threads_conf" :
  * [
- *	{ "index" : 0, "intensity" : 1000, "worksize" : 8, "affine_to_cpu" : false, "strided_index" : true },
+ *	{ "index" : 0, "intensity" : 1000, "extra_intensity" : 0, "worksize" : 8, "affine_to_cpu" : false, "strided_index" : true },
  * ],
  */
 

--- a/xmrstak/backend/amd/jconf.cpp
+++ b/xmrstak/backend/amd/jconf.cpp
@@ -103,17 +103,18 @@ bool jconf::GetThreadConfig(size_t id, thd_cfg &cfg)
 	if(!oThdConf.IsObject())
 		return false;
 
-	const Value *idx, *intensity, *w_size, *aff, *stridedIndex;
+	const Value *idx, *intensity, *extraIntensity, *w_size, *aff, *stridedIndex;
 	idx = GetObjectMember(oThdConf, "index");
 	intensity = GetObjectMember(oThdConf, "intensity");
+	extraIntensity = GetObjectMember(oThdConf, "extra_intensity");
 	w_size = GetObjectMember(oThdConf, "worksize");
 	aff = GetObjectMember(oThdConf, "affine_to_cpu");
 	stridedIndex = GetObjectMember(oThdConf, "strided_index");
 
-	if(idx == nullptr || intensity == nullptr || w_size == nullptr || aff == nullptr || stridedIndex == nullptr)
+	if(idx == nullptr || intensity == nullptr || extraIntensity == nullptr || w_size == nullptr || aff == nullptr || stridedIndex == nullptr)
 		return false;
 
-	if(!idx->IsUint64() || !intensity->IsUint64() || !w_size->IsUint64())
+	if(!idx->IsUint64() || !intensity->IsUint64() || !extraIntensity->IsUint64()|| !w_size->IsUint64())
 		return false;
 
 	if(!aff->IsUint64() && !aff->IsBool())
@@ -124,6 +125,7 @@ bool jconf::GetThreadConfig(size_t id, thd_cfg &cfg)
 
 	cfg.index = idx->GetUint64();
 	cfg.intensity = intensity->GetUint64();
+	cfg.extraIntensity = extraIntensity->GetUint64();
 	cfg.w_size = w_size->GetUint64();
 	cfg.stridedIndex = stridedIndex->GetBool();
 

--- a/xmrstak/backend/amd/jconf.hpp
+++ b/xmrstak/backend/amd/jconf.hpp
@@ -27,6 +27,7 @@ public:
 		size_t w_size;
 		long long cpu_aff;
 		bool stridedIndex;
+		size_t extraIntensity;
 	};
 
 	size_t GetThreadCount();

--- a/xmrstak/backend/amd/minethd.cpp
+++ b/xmrstak/backend/amd/minethd.cpp
@@ -95,6 +95,7 @@ bool minethd::init_gpus()
 		jconf::inst()->GetThreadConfig(i, cfg);
 		vGpuData[i].deviceIdx = cfg.index;
 		vGpuData[i].rawIntensity = cfg.intensity;
+		vGpuData[i].rawExtraIntensity = cfg.extraIntensity;
 		vGpuData[i].workSize = cfg.w_size;
 		vGpuData[i].stridedIndex = cfg.stridedIndex;
 	}
@@ -208,7 +209,7 @@ void minethd::work_main()
 			continue;
 		}
 
-		uint32_t h_per_round = pGpuCtx->rawIntensity;
+		uint32_t h_per_round = pGpuCtx->rawIntensity + pGpuCtx->rawExtraIntensity;
 		size_t round_ctr = 0;
 
 		assert(sizeof(job_result::sJobID) == sizeof(pool_job::sJobID));
@@ -248,7 +249,7 @@ void minethd::work_main()
 					executor::inst()->push_event(ex_event("AMD Invalid Result", oWork.iPoolId));
 			}
 
-			iCount += pGpuCtx->rawIntensity;
+			iCount += pGpuCtx->rawIntensity + pGpuCtx->rawExtraIntensity;
 			uint64_t iStamp = get_timestamp_ms();
 			iHashCount.store(iCount, std::memory_order_relaxed);
 			iTimestamp.store(iStamp, std::memory_order_relaxed);


### PR DESCRIPTION
use extra available memory with `CL_MEM_USE_PERSISTENT_MEM_AMD ` suggested in #567

- add new AMD backend option `extra_intensity`
- extra intensity will be use the VRAM of the GPU which can be addressed by the host and device

# HowTo Test

- compile the new pull request, direct download: https://github.com/psychocrypt/xmr-stak/archive/topic-extraIntensity.zip
- rename you current used amd.txt
- start the miner
- stop the miner
- increase slowly the value for `extra_intensity` (begin with 8)
- test if the hash rate increase

**Note:**  There is only a limited amount of memory for `extra_intensity` available. The amount of memory is in the most cases 256MB which means you can increase `extra_intensity` not over `128` but maybe also this value is not available. For VEGA GPUs the new option should be only used for the thread with the smaller intensity.
**Note2** It could be that it is possible to increase the `extra_intensity` over 128. If so please try if it is possible to use only one thread for the VEGA GPU and set `extra_intensity` to the same value you are normally use for the second thread of the gpu.
**WARNING** it could be that it is not possible to use different paramater for the intensity and extra_intensity for the first and second thread used to utilize one VEGA GPU. If so please report it to me.

# Report your hash rate

- please report the hash rate of the current dev/master and with the pull request. Please also include the amd.txt config you used.
- there is also a new message on the command line `... AMD extra memory is ...`. Please post the exact message with you hash rate results.