### PR TITLE
Add warning and fallback when auto intensity is 0

### DIFF
--- a/xmrstak/backend/amd/autoAdjust.hpp
+++ b/xmrstak/backend/amd/autoAdjust.hpp
@@ -94,7 +94,6 @@ private:
 		}
 
 		std::string conf;
-		int i = 0;
 		for(auto& ctx : devVec)
 		{
 			/* 1000 is a magic selected limit, the reason is that more than 2GiB memory
@@ -119,26 +118,26 @@ private:
 			// map intensity to a multiple of the compute unit count, 8 is the number of threads per work group
 			size_t intensity = (possibleIntensity / (8 * ctx.computeUnits)) * ctx.computeUnits * 8;
 			//If the intensity is 0, then it's because the multiple of the unit count is greater than intensity
-			if (intensity == 0) {
-				/* See Issues:
-				 * https://github.com/fireice-uk/xmr-stak/issues/81
-				 * https://github.com/fireice-uk/xmr-stak/issues/472
-				 * https://github.com/fireice-uk/xmr-stak/issues/490
-				 * Note that it appears that Northern Islands GPUs (HD 6XXX) are unaffected by
-				 * these environment variables, according to my testing (dougvj)
-				 */
-				printer::inst()->print_msg(L0, "WARNING: Autodetected intensity unexpectedly low. Try setting GPU_SINGLE_ALLOC_PERCENT and etc.");
+			if (intensity == 0)
+			{
+				printer::inst()->print_msg(L0, "WARNING: Auto detected intensity unexpectedly low. Try to set the environment variable GPU_SINGLE_ALLOC_PERCENT.");
 				intensity = possibleIntensity;
 
 			}
-			conf += std::string("  // gpu: ") + ctx.name + " memory:" + std::to_string(availableMem / byteToMiB) + "\n";
-			conf += std::string("  // compute units: ") + std::to_string(ctx.computeUnits) + "\n";
-			// set 8 threads per block (this is a good value for the most gpus)
-			conf += std::string("  { \"index\" : ") + std::to_string(ctx.deviceIdx) + ",\n" +
-				"    \"intensity\" : " + std::to_string(intensity) + ", \"worksize\" : " + std::to_string(8) + ",\n" +
-				"    \"affine_to_cpu\" : false, \"strided_index\" : true\n"
-				"  },\n";
-			++i;
+			if (intensity != 0)
+			{
+				conf += std::string("  // gpu: ") + ctx.name + " memory:" + std::to_string(availableMem / byteToMiB) + "\n";
+				conf += std::string("  // compute units: ") + std::to_string(ctx.computeUnits) + "\n";
+				// set 8 threads per block (this is a good value for the most gpus)
+				conf += std::string("  { \"index\" : ") + std::to_string(ctx.deviceIdx) + ",\n" +
+					"    \"intensity\" : " + std::to_string(intensity) + ", \"worksize\" : " + std::to_string(8) + ",\n" +
+					"    \"affine_to_cpu\" : false, \"strided_index\" : true\n"
+					"  },\n";
+			}
+			else
+			{
+				printer::inst()->print_msg(L0, "WARNING: Ignore gpu %s, %s MiB free memory is not enough to suggest settings.", ctx.name.c_str(), std::to_string(availableMem / byteToMiB).c_str());
+			}
 		}
 
 		configTpl.replace("PLATFORMINDEX",std::to_string(platformIndex));

--- a/xmrstak/backend/amd/autoAdjust.hpp
+++ b/xmrstak/backend/amd/autoAdjust.hpp
@@ -118,6 +118,19 @@ private:
 			size_t possibleIntensity = std::min( maxThreads , maxIntensity );
 			// map intensity to a multiple of the compute unit count, 8 is the number of threads per work group
 			size_t intensity = (possibleIntensity / (8 * ctx.computeUnits)) * ctx.computeUnits * 8;
+			//If the intensity is 0, then it's because the multiple of the unit count is greater than intensity
+			if (intensity == 0) {
+				/* See Issues:
+				 * https://github.com/fireice-uk/xmr-stak/issues/81
+				 * https://github.com/fireice-uk/xmr-stak/issues/472
+				 * https://github.com/fireice-uk/xmr-stak/issues/490
+				 * Note that it appears that Northern Islands GPUs (HD 6XXX) are unaffected by
+				 * these environment variables, according to my testing (dougvj)
+				 */
+				printer::inst()->print_msg(L0, "WARNING: Autodetected intensity unexpectedly low. Try setting GPU_SINGLE_ALLOC_PERCENT and etc.");
+				intensity = possibleIntensity;
+
+			}
 			conf += std::string("  // gpu: ") + ctx.name + " memory:" + std::to_string(availableMem / byteToMiB) + "\n";
 			conf += std::string("  // compute units: ") + std::to_string(ctx.computeUnits) + "\n";
 			// set 8 threads per block (this is a good value for the most gpus)


### PR DESCRIPTION
Occassionally the auto adjust doesn't find enough memory and the
intensity is detected too low and aligned to 0 with the compute units.
This patch fixes this situation by issuing a warning with a suggestion
to set environment vars and then ignoring the alignment to 0

Per several issues:

Principally:
https://github.com/fireice-uk/xmr-stak/issues/81

Related:
https://github.com/fireice-uk/xmr-stak/issues/490
https://github.com/fireice-uk/xmr-stak/issues/472