### PR TITLE
AMD compile instructions for macOS

### DIFF
--- a/doc/compile_MacOS.md
+++ b/doc/compile_MacOS.md
@@ -18,7 +18,11 @@ make install
 
 ### For AMD GPUs
 
-> 🖐 We need help with AMD GPU compilation instructions. Please submit a PR if you managed to install [AMD APP SDK](http://developer.amd.com/amd-accelerated-parallel-processing-app-sdk/) and to compile `xmr-stak` on MacOS.
+```shell
+brew install hwloc libmicrohttpd gcc openssl cmake
+cmake . -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl -DCUDA_ENABLE=OFF -DOpenCL_ENABLE=ON
+make install
+```
 
 ### For CPU-only mining
 

--- a/doc/compile_MacOS.md
+++ b/doc/compile_MacOS.md
@@ -18,6 +18,8 @@ make install
 
 ### For AMD GPUs
 
+OpenCL is bundled with Xcode, so no other depedency then the basic ones needed. Just enable OpenCL via the `-DOpenCL_ENABLE=ON` CMake option.
+
 ```shell
 brew install hwloc libmicrohttpd gcc openssl cmake
 cmake . -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl -DCUDA_ENABLE=OFF -DOpenCL_ENABLE=ON


### PR DESCRIPTION
I'm using an AMD powered MacBook Pro and saw the note about missing info in the HowTo. That's what worked for me. I basically just turned on OpenCL support and disabled the CUDA support.