### PR TITLE
Fix bug in pool-side hashes

### DIFF
--- a/xmrstak/misc/executor.hpp
+++ b/xmrstak/misc/executor.hpp
@@ -177,7 +177,6 @@ private:
 		iPoolCallTimes.clear();
 		tPoolConnTime = std::chrono::system_clock::now();
 		iPoolHashes = 0;
-		iPoolDiff = 0;
 	}
 
 	double fHighestHps = 0.0;


### PR DESCRIPTION
Fixes bug reported in #607 

To test, simply run and observe difficulty and pool-side hashes. Pool-side hashes should increase by difficulty every time the miner submits a result.