### PR TITLE
fix set affinity for windows

### DIFF
--- a/xmrstak/backend/cpu/minethd.cpp
+++ b/xmrstak/backend/cpu/minethd.cpp
@@ -73,7 +73,16 @@ namespace cpu
 bool minethd::thd_setaffinity(std::thread::native_handle_type h, uint64_t cpu_id)
 {
 #if defined(_WIN32)
-	return SetThreadAffinityMask(h, 1ULL << cpu_id) != 0;
+	// we can only pin up to 64 threads
+	if(cpu_id < 64)
+	{
+		return SetThreadAffinityMask(h, 1ULL << cpu_id) != 0;
+	}
+	else
+	{
+		printer::inst()->print_msg(L0, "WARNING: Windows supports only affinity up to 63.");
+		return false;
+	}
 #elif defined(__APPLE__)
 	thread_port_t mach_thread;
 	thread_affinity_policy_data_t policy = { static_cast<integer_t>(cpu_id) };


### PR DESCRIPTION
Ignore any affinity >=64 and throw a warning.