### PR TITLE
Fix for compiling with Cuda 9.1 on VS 2017 version >= 15.5

### DIFF
--- a/doc/compile_Windows.md
+++ b/doc/compile_Windows.md
@@ -13,6 +13,7 @@
 - during the install chose the components
   - `Desktop development with C++` (left side)
   - `VC++ 2015.3 v140 toolset for desktop` (right side)
+  - Since release of VS2017 15.5 (12/04/17), require `VC++ 2017 version 15.4 v14.11 toolset` (under tab `Individual Components`, section `Compilers, build tools, and runtimes`), as CUDA 9.1 is not compatible with compiler 14.12.X
 
 ### CMake for Win64
 
@@ -80,6 +81,8 @@
 - `cd` to your unzipped source code directory
 - execute the following commands (NOTE: path to VS2017 can be different)
   ```
+  # Next line is only if compiling for Cuda 9.1 and using Visual Studio 2017 >= 15.5 (released 12/04/17)
+  "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" x64 -vcvars_ver=14.11  
   "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\VsMSBuildCmd.bat"
   set CMAKE_PREFIX_PATH=C:\xmr-stak-dep\hwloc;C:\xmr-stak-dep\libmicrohttpd;C:\xmr-stak-dep\openssl
   mkdir build


### PR DESCRIPTION
Fix for #750, #626, #606, #534, without having to downgrade and do not require modification of host_config.h
Require an additional component during VS2017 installation (VC++ 2017 version 15.4 v14.11 toolset) and an additional command execution before compilation.