### PR TITLE
reduce memory usage for low end gpus

### DIFF
--- a/xmrstak/backend/nvidia/nvcc_code/cuda_extra.cu
+++ b/xmrstak/backend/nvidia/nvcc_code/cuda_extra.cu
@@ -441,6 +441,12 @@ extern "C" int cuda_get_deviceinfo(nvid_ctx* ctx)
 			maxMemUsage = size_t(1024u) * byteToMiB;
 		}
 
+		if(props.multiProcessorCount <= 6)
+		{
+			// limit memory usage for low end devices to reduce the number of threads
+			maxMemUsage = size_t(1024u) * byteToMiB;
+		}
+
 		int* tmp;
 		cudaError_t err;
 		// a device must be selected to get the right memory usage later on


### PR DESCRIPTION
reduce memory usage to 1GiB for NVIDIA devices with <=6 SMX

This PR should solve many issue we will have with low end NVIDIA GPUs. The GPUs are not able to compute enough hashes within 10 sec. 