### PR TITLE
avoid expired blocks

### DIFF
--- a/xmrstak/backend/amd/minethd.cpp
+++ b/xmrstak/backend/amd/minethd.cpp
@@ -172,6 +172,7 @@ void minethd::consume_work()
 {
 	memcpy(&oWork, &globalStates::inst().oGlobalWork, sizeof(miner_work));
 	iJobNo++;
+	lastPool=globalStates::inst().pool_id.load(std::memory_order_relaxed);
 	globalStates::inst().iConsumeCnt++;
 
 }
@@ -231,21 +232,30 @@ void minethd::work_main()
 
 			XMRRunJob(pGpuCtx, results);
 
-			for(size_t i = 0; i < results[0xFF]; i++)
+			/* Send shares only if we switched the pool or if the job has not changed.
+			 * The condition that shares get also evaluated if the pool is changed avoid
+			 * that the last bunch of hashes get automaticly ignored if we switch from the dev to the
+			 * user pool or via verse.
+			 */
+			if(globalStates::inst().pool_id.load(std::memory_order_relaxed) != lastPool ||
+				globalStates::inst().iGlobalJobNo.load(std::memory_order_relaxed) == iJobNo)
 			{
-				uint8_t	bWorkBlob[112];
-				uint8_t	bResult[32];
+				for(size_t i = 0; i < results[0xFF]; i++)
+				{
+					uint8_t	bWorkBlob[112];
+					uint8_t	bResult[32];
 
-				memcpy(bWorkBlob, oWork.bWorkBlob, oWork.iWorkSize);
-				memset(bResult, 0, sizeof(job_result::bResult));
+					memcpy(bWorkBlob, oWork.bWorkBlob, oWork.iWorkSize);
+					memset(bResult, 0, sizeof(job_result::bResult));
 
-				*(uint32_t*)(bWorkBlob + 39) = results[i];
+					*(uint32_t*)(bWorkBlob + 39) = results[i];
 
-				hash_fun(bWorkBlob, oWork.iWorkSize, bResult, cpu_ctx);
-				if ( (*((uint64_t*)(bResult + 24))) < oWork.iTarget)
-					executor::inst()->push_event(ex_event(job_result(oWork.sJobID, results[i], bResult, iThreadNo), oWork.iPoolId));
-				else
-					executor::inst()->push_event(ex_event("AMD Invalid Result", pGpuCtx->deviceIdx, oWork.iPoolId));
+					hash_fun(bWorkBlob, oWork.iWorkSize, bResult, cpu_ctx);
+					if ( (*((uint64_t*)(bResult + 24))) < oWork.iTarget)
+						executor::inst()->push_event(ex_event(job_result(oWork.sJobID, results[i], bResult, iThreadNo), oWork.iPoolId));
+					else
+						executor::inst()->push_event(ex_event("AMD Invalid Result", pGpuCtx->deviceIdx, oWork.iPoolId));
+				}
 			}
 
 			iCount += pGpuCtx->rawIntensity;

--- a/xmrstak/backend/amd/minethd.hpp
+++ b/xmrstak/backend/amd/minethd.hpp
@@ -33,6 +33,7 @@ private:
 	void consume_work();
 
 	uint64_t iJobNo;
+	uint64_t lastPool;
 
 	static miner_work oGlobalWork;
 	miner_work oWork;

--- a/xmrstak/backend/globalStates.cpp
+++ b/xmrstak/backend/globalStates.cpp
@@ -44,8 +44,7 @@ void globalStates::switch_work(miner_work& pWork, pool_data& dat)
 		std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
 	size_t xid = dat.pool_id;
-	dat.pool_id = pool_id;
-	pool_id = xid;
+	dat.pool_id = pool_id.exchange(xid, std::memory_order_relaxed);
 
 	dat.iSavedNonce = iGlobalNonce.exchange(dat.iSavedNonce, std::memory_order_seq_cst);
 	oGlobalWork = pWork;

--- a/xmrstak/backend/globalStates.hpp
+++ b/xmrstak/backend/globalStates.hpp
@@ -47,11 +47,12 @@ struct globalStates
 	std::atomic<uint64_t> iConsumeCnt;
 	std::atomic<uint32_t> iGlobalNonce;
 	uint64_t iThreadCount;
-	size_t pool_id = invalid_pool_id;
+	std::atomic<size_t> pool_id;
 
 private:
 	globalStates() : iThreadCount(0)
 	{
+		pool_id.store(invalid_pool_id, std::memory_order_seq_cst);
 	}
 };
 

--- a/xmrstak/backend/nvidia/minethd.hpp
+++ b/xmrstak/backend/nvidia/minethd.hpp
@@ -40,6 +40,7 @@ private:
 	static std::atomic<uint64_t> iConsumeCnt;
 	static uint64_t iThreadCount;
 	uint64_t iJobNo;
+	uint64_t lastPool;
 
 	static miner_work oGlobalWork;
 	miner_work oWork;


### PR DESCRIPTION
- change `pool_id` in `globalStats` to atomic
- check if the pool has changed during a bunch of hashes is calculated

Shares from the AMD and NVIDIA back-end will not be submitted if the job has changed. In the case the pool is changed in the same moment the shares will be send else the user will lose all solved shares if we switch to the dev pool. 

- [x] runtime tests AMD (8h)
- [x] runtime tests NVIDIA (2h)