### PR TITLE
avoid nonce overlappping

### DIFF
--- a/xmrstak/backend/cpu/minethd.cpp
+++ b/xmrstak/backend/cpu/minethd.cpp
@@ -448,7 +448,7 @@ void minethd::work_main()
 				globalStates::inst().calc_start_nonce(result.iNonce, oWork.bNiceHash, nonce_chunk);
 			}
 
-			*piNonce = ++result.iNonce;
+			*piNonce = result.iNonce++;
 
 			hash_fun(oWork.bWorkBlob, oWork.iWorkSize, result.bResult, ctx);
 
@@ -637,7 +637,7 @@ void minethd::multiway_work_main(cn_hash_fun_multi hash_fun_multi)
 			}
 
 			for (size_t i = 0; i < N; i++)
-				*piNonce[i] = ++iNonce;
+				*piNonce[i] = iNonce++;
 
 			hash_fun_multi(bWorkBlob, oWork.iWorkSize, bHashOut, ctx);
 
@@ -645,7 +645,7 @@ void minethd::multiway_work_main(cn_hash_fun_multi hash_fun_multi)
 			{
 				if (*piHashVal[i] < oWork.iTarget)
 				{
-					executor::inst()->push_event(ex_event(job_result(oWork.sJobID, iNonce - N + 1 + i, bHashOut + 32 * i, iThreadNo), oWork.iPoolId));
+					executor::inst()->push_event(ex_event(job_result(oWork.sJobID, iNonce - N + i, bHashOut + 32 * i, iThreadNo), oWork.iPoolId));
 				}
 			}
 


### PR DESCRIPTION
The cpu miner backend uses the wrong ranges of nonces instead of using `[startNonce,startNonce + nonce_chunk)`
(startNonce,startNonce + nonce_chunk]` is used. This will results in an overlap with nonces used by the gpu back-ends.
