### PR TITLE
avoid nonce overlapping

### DIFF
--- a/xmrstak/backend/cpu/minethd.cpp
+++ b/xmrstak/backend/cpu/minethd.cpp
@@ -448,12 +448,13 @@ void minethd::work_main()
 				globalStates::inst().calc_start_nonce(result.iNonce, oWork.bNiceHash, nonce_chunk);
 			}
 
-			*piNonce = ++result.iNonce;
+			*piNonce = result.iNonce;
 
 			hash_fun(oWork.bWorkBlob, oWork.iWorkSize, result.bResult, ctx);
 
 			if (*piHashVal < oWork.iTarget)
 				executor::inst()->push_event(ex_event(result, oWork.iPoolId));
+			result.iNonce++;
 
 			std::this_thread::yield();
 		}
@@ -637,7 +638,7 @@ void minethd::multiway_work_main(cn_hash_fun_multi hash_fun_multi)
 			}
 
 			for (size_t i = 0; i < N; i++)
-				*piNonce[i] = ++iNonce;
+				*piNonce[i] = iNonce++;
 
 			hash_fun_multi(bWorkBlob, oWork.iWorkSize, bHashOut, ctx);
 
@@ -645,7 +646,7 @@ void minethd::multiway_work_main(cn_hash_fun_multi hash_fun_multi)
 			{
 				if (*piHashVal[i] < oWork.iTarget)
 				{
-					executor::inst()->push_event(ex_event(job_result(oWork.sJobID, iNonce - N + 1 + i, bHashOut + 32 * i, iThreadNo), oWork.iPoolId));
+					executor::inst()->push_event(ex_event(job_result(oWork.sJobID, iNonce - N + i, bHashOut + 32 * i, iThreadNo), oWork.iPoolId));
 				}
 			}
 


### PR DESCRIPTION
follow up of #978

The cpu miner backend uses the wrong ranges of nonces instead of using `[startNonce,startNonce + nonce_chunk)`
(startNonce,startNonce + nonce_chunk]` is used. This will results in an overlap with nonces used by the gpu back-ends.

I used the [mathematics interval](https://en.wikipedia.org/wiki/Interval_(mathematics)) notation to to describe valid nonces which can be used based on the `start_none` from [here](https://github.com/fireice-uk/xmr-stak/blob/2ae7260b90fe3dbe835ba2489519510f0e57d770/xmrstak/backend/cpu/minethd.cpp#L437) .

e.g. if the `result.iNonce` is `20` and `nonce_chunk` is 4 than `[20,24)` are allowed nonces.
In line [440](https://github.com/fireice-uk/xmr-stak/blob/2ae7260b90fe3dbe835ba2489519510f0e57d770/xmrstak/backend/cpu/minethd.cpp#L440) `result.iNonce` is first increased and than assigned to `*piNince`, this means that the first nonce used by the miner is `21` instead of `20` in our example. The last used nonce is `24` instead of `23`.

The gpu miner uses the correct intervals for the nonce from `[startNonce,startNonce+nonce_chunk). Therefore the used nonces of the GPU and CPU will overlap by one.

This PR fixes the issue by changing `++result.iNonce` to `result.iNonce**` to first assign the old value and than increment to `result.iNonce`