### PR TITLE
Replace "function() failed" with strerror()

### DIFF
--- a/xmrstak/backend/cpu/crypto/cryptonight_common.cpp
+++ b/xmrstak/backend/cpu/crypto/cryptonight_common.cpp
@@ -255,18 +255,18 @@ cryptonight_ctx* cryptonight_alloc_ctx(size_t use_fast_mem, size_t use_mlock, al
 	if (ptr->long_state == MAP_FAILED)
 	{
 		_mm_free(ptr);
-		msg->warning = "mmap failed";
+		msg->warning = strerror(errno);
 		return NULL;
 	}
 
 	ptr->ctx_info[0] = 1;
 
 	if(madvise(ptr->long_state, hashMemSize, MADV_RANDOM|MADV_WILLNEED) != 0)
-		msg->warning = "madvise failed";
+		msg->warning = strerror(errno);
 
 	ptr->ctx_info[1] = 0;
 	if(use_mlock != 0 && mlock(ptr->long_state, hashMemSize) != 0)
-		msg->warning = "mlock failed";
+		msg->warning = strerror(errno);
 	else
 		ptr->ctx_info[1] = 1;
 


### PR DESCRIPTION
It would be even better to use "mlock(<args>): " + strerror(errno) but that would require memory allocation and deallocation.

Rationale: I got a mlock failed and ignored it, while it is actually an ENOMEM which probably can be fixed with setting ulimit appropriately.

Please make sure your PR is against **dev** branch. Merging PRs directly into master branch would interfere with our workflow.