### PR TITLE
use persistent AMD memory

### DIFF
--- a/xmrstak/backend/amd/amd_gpu/gpu.hpp
+++ b/xmrstak/backend/amd/amd_gpu/gpu.hpp
@@ -38,6 +38,7 @@ struct GpuContext
 	int computeUnits;
 	std::string name;
 
+	bool isAMDGpu = true;
 	uint32_t Nonce;
 
 };


### PR DESCRIPTION
Use CL_MEM_USE_PERSISTENT_MEM_AMD for AMD gpus to story all buffers expect the hash scratchpad.
This PR allows to increase the intensity a little bit more before the GPU is running out of memory.
This PR increases the hash rate a little bit (a few hashes e.g. on a RX570).

- [ ] must be tested on older dives like HD78XX or HD79XX