### PR TITLE
disable OSX CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,10 +70,10 @@ matrix:
         - CMAKE_C_COMPILER=gcc-7
         - XMRSTAK_CMAKE_FLAGS="-DCUDA_ENABLE=OFF -DOpenCL_ENABLE=OFF"
 
-    - os: osx
-      compiler: gcc
-      env:
-        - XMRSTAK_CMAKE_FLAGS="-DCUDA_ENABLE=OFF -DOpenCL_ENABLE=OFF"
+#    - os: osx
+#      compiler: gcc
+#      env:
+#        - XMRSTAK_CMAKE_FLAGS="-DCUDA_ENABLE=OFF -DOpenCL_ENABLE=OFF"
 
 before_install:
   - . CI/checkPRBranch


### PR DESCRIPTION
Currently the CI fails due to the issue
```
Error: homebrew/science was deprecated. This tap is now empty as all its formulae were migrated.
The command "if [ $TRAVIS_OS_NAME = osx ]; then brew update; brew tap homebrew/science; fi" failed and exited with 1 during .
```
Until the fix is implemented the OSX tests will be disabled.
