### PR TITLE
fix missing message in log file

### DIFF
--- a/xmrstak/cli/cli-miner.cpp
+++ b/xmrstak/cli/cli-miner.cpp
@@ -627,6 +627,9 @@ int main(int argc, char *argv[])
 	}
 #endif
 
+	if(strlen(jconf::inst()->GetOutputFile()) != 0)
+		printer::inst()->open_logfile(jconf::inst()->GetOutputFile());
+
 	if (!BackendConnector::self_test())
 	{
 		win_exit();
@@ -671,9 +674,6 @@ int main(int argc, char *argv[])
 		printer::inst()->print_msg(L0,"Start mining: MONERO");
 	else
 		printer::inst()->print_msg(L0,"Start mining: AEON");
-
-	if(strlen(jconf::inst()->GetOutputFile()) != 0)
-		printer::inst()->open_logfile(jconf::inst()->GetOutputFile());
 
 	executor::inst()->ex_start(jconf::inst()->DaemonMode());
 


### PR DESCRIPTION
Some messages from the start of the miner are not printed to the log file. The reason is that the log file is initialized to late. For hash rate monitors it is important to detect the last start in the log files. 
Thx @JerichoJones for reporting of this issue.

- initialize the log file as fast as possible after the start of the miner
 