### PR TITLE
Fixed invalid json respose wht the connection log contained newlines.

### DIFF
--- a/xmrstak/misc/executor.cpp
+++ b/xmrstak/misc/executor.cpp
@@ -44,6 +44,7 @@
 #include <functional>
 #include <assert.h>
 #include <time.h>
+#include <regex>
 
 
 #ifdef _WIN32
@@ -1222,9 +1223,11 @@ void executor::http_json_report(std::string& out)
 		using namespace std::chrono;
 		if(i != 0) cn_error.append(1, ',');
 
+		std::string logMsg(std::regex_replace(vSocketLog[i].msg, std::regex("\n\r"), " "));
+
 		snprintf(buffer, sizeof(buffer), sJsonApiConnectionError,
 			int_port(duration_cast<seconds>(vMineResults[i].time.time_since_epoch()).count()),
-			vSocketLog[i].msg.c_str());
+			logMsg.c_str());
 		cn_error.append(buffer);
 	}
 


### PR DESCRIPTION
This addresses the invalid status shown by Awesome Miner, if xmr-stak reconnected to the nano pool.
