### PR TITLE
Changes for the Monero v1 PoW

### DIFF
--- a/xmrstak/backend/amd/amd_gpu/gpu.cpp
+++ b/xmrstak/backend/amd/amd_gpu/gpu.cpp
@@ -705,7 +705,7 @@ size_t InitOpenCL(GpuContext* ctx, size_t num_gpus, size_t platform_idx)
 	return ERR_SUCCESS;
 }
 
-size_t XMRSetJob(GpuContext* ctx, uint8_t* input, size_t input_len, uint64_t target)
+size_t XMRSetJob(GpuContext* ctx, uint8_t* input, size_t input_len, uint64_t target, uint32_t version)
 {
 	cl_int ret;
 
@@ -771,6 +771,20 @@ size_t XMRSetJob(GpuContext* ctx, uint8_t* input, size_t input_len, uint64_t tar
 	{
 		printer::inst()->print_msg(L1,"Error %s when calling clSetKernelArg for kernel 1, argument 2.", err_to_str(ret));
 		return(ERR_OCL_API);
+	}
+
+	// Version
+	if((ret = clSetKernelArg(ctx->Kernels[1], 3, sizeof(cl_uint), &version)) != CL_SUCCESS)
+	{
+		printer::inst()->print_msg(L1,"Error %s when calling clSetKernelArg for kernel 1, argument 3.", err_to_str(ret));
+		return ERR_OCL_API;
+	}
+
+	// Input
+	if ((ret = clSetKernelArg(ctx->Kernels[1], 4, sizeof(cl_mem), &ctx->InputBuffer)) != CL_SUCCESS)
+	{
+		printer::inst()->print_msg(L1, "Error %s when calling clSetKernelArg for kernel 1, arugment 4.", err_to_str(ret));
+		return ERR_OCL_API;
 	}
 
 	// CN3 Kernel

--- a/xmrstak/backend/amd/amd_gpu/gpu.hpp
+++ b/xmrstak/backend/amd/amd_gpu/gpu.hpp
@@ -47,7 +47,7 @@ int getAMDPlatformIdx();
 std::vector<GpuContext> getAMDDevices(int index);
 
 size_t InitOpenCL(GpuContext* ctx, size_t num_gpus, size_t platform_idx);
-size_t XMRSetJob(GpuContext* ctx, uint8_t* input, size_t input_len, uint64_t target);
+size_t XMRSetJob(GpuContext* ctx, uint8_t* input, size_t input_len, uint64_t target, uint32_t variant);
 size_t XMRRunJob(GpuContext* ctx, cl_uint* HashOutput);
 
 

--- a/xmrstak/backend/amd/minethd.hpp
+++ b/xmrstak/backend/amd/minethd.hpp
@@ -25,7 +25,7 @@ public:
 	static bool init_gpus();
 
 private:
-	typedef void (*cn_hash_fun)(const void*, size_t, void*, cryptonight_ctx*);
+	typedef void (*cn_hash_fun)(const void*, size_t, void*, cryptonight_ctx*, uint8_t);
 
 	minethd(miner_work& pWork, size_t iNo, GpuContext* ctx, const jconf::thd_cfg cfg);
 

--- a/xmrstak/backend/cpu/minethd.cpp
+++ b/xmrstak/backend/cpu/minethd.cpp
@@ -228,38 +228,38 @@ bool minethd::self_test()
 		cn_hash_fun_multi hashf_multi;
 
 		hashf = func_selector(::jconf::inst()->HaveHardwareAes(), false, mineMonero);
-		hashf("This is a test", 14, out, ctx[0]);
+		hashf("This is a test", 14, out, ctx[0], 0);
 		bResult = memcmp(out, "\xa0\x84\xf0\x1d\x14\x37\xa0\x9c\x69\x85\x40\x1b\x60\xd4\x35\x54\xae\x10\x58\x02\xc5\xf5\xd8\xa9\xb3\x25\x36\x49\xc0\xbe\x66\x05", 32) == 0;
 
 		hashf = func_selector(::jconf::inst()->HaveHardwareAes(), true, mineMonero);
-		hashf("This is a test", 14, out, ctx[0]);
+		hashf("This is a test", 14, out, ctx[0], 0);
 		bResult &= memcmp(out, "\xa0\x84\xf0\x1d\x14\x37\xa0\x9c\x69\x85\x40\x1b\x60\xd4\x35\x54\xae\x10\x58\x02\xc5\xf5\xd8\xa9\xb3\x25\x36\x49\xc0\xbe\x66\x05", 32) == 0;
 
 		hashf_multi = func_multi_selector(2, ::jconf::inst()->HaveHardwareAes(), false, mineMonero);
-		hashf_multi("The quick brown fox jumps over the lazy dogThe quick brown fox jumps over the lazy log", 43, out, ctx);
+		hashf_multi("The quick brown fox jumps over the lazy dogThe quick brown fox jumps over the lazy log", 43, out, ctx, 0);
 		bResult &= memcmp(out, "\x3e\xbb\x7f\x9f\x7d\x27\x3d\x7c\x31\x8d\x86\x94\x77\x55\x0c\xc8\x00\xcf\xb1\x1b\x0c\xad\xb7\xff\xbd\xf6\xf8\x9f\x3a\x47\x1c\x59"
 				"\xb4\x77\xd5\x02\xe4\xd8\x48\x7f\x42\xdf\xe3\x8e\xed\x73\x81\x7a\xda\x91\xb7\xe2\x63\xd2\x91\x71\xb6\x5c\x44\x3a\x01\x2a\x41\x22", 64) == 0;
 
 		hashf_multi = func_multi_selector(2, ::jconf::inst()->HaveHardwareAes(), true, mineMonero);
-		hashf_multi("The quick brown fox jumps over the lazy dogThe quick brown fox jumps over the lazy log", 43, out, ctx);
+		hashf_multi("The quick brown fox jumps over the lazy dogThe quick brown fox jumps over the lazy log", 43, out, ctx, 0);
 		bResult &= memcmp(out, "\x3e\xbb\x7f\x9f\x7d\x27\x3d\x7c\x31\x8d\x86\x94\x77\x55\x0c\xc8\x00\xcf\xb1\x1b\x0c\xad\xb7\xff\xbd\xf6\xf8\x9f\x3a\x47\x1c\x59"
 				"\xb4\x77\xd5\x02\xe4\xd8\x48\x7f\x42\xdf\xe3\x8e\xed\x73\x81\x7a\xda\x91\xb7\xe2\x63\xd2\x91\x71\xb6\x5c\x44\x3a\x01\x2a\x41\x22", 64) == 0;
 
 		hashf_multi = func_multi_selector(3, ::jconf::inst()->HaveHardwareAes(), false, mineMonero);
-		hashf_multi("This is a testThis is a testThis is a test", 14, out, ctx);
+		hashf_multi("This is a testThis is a testThis is a test", 14, out, ctx, 0);
 		bResult &= memcmp(out, "\xa0\x84\xf0\x1d\x14\x37\xa0\x9c\x69\x85\x40\x1b\x60\xd4\x35\x54\xae\x10\x58\x02\xc5\xf5\xd8\xa9\xb3\x25\x36\x49\xc0\xbe\x66\x05"
 				"\xa0\x84\xf0\x1d\x14\x37\xa0\x9c\x69\x85\x40\x1b\x60\xd4\x35\x54\xae\x10\x58\x02\xc5\xf5\xd8\xa9\xb3\x25\x36\x49\xc0\xbe\x66\x05"
 				"\xa0\x84\xf0\x1d\x14\x37\xa0\x9c\x69\x85\x40\x1b\x60\xd4\x35\x54\xae\x10\x58\x02\xc5\xf5\xd8\xa9\xb3\x25\x36\x49\xc0\xbe\x66\x05", 96) == 0;
 
 		hashf_multi = func_multi_selector(4, ::jconf::inst()->HaveHardwareAes(), false, mineMonero);
-		hashf_multi("This is a testThis is a testThis is a testThis is a test", 14, out, ctx);
+		hashf_multi("This is a testThis is a testThis is a testThis is a test", 14, out, ctx, 0);
 		bResult &= memcmp(out, "\xa0\x84\xf0\x1d\x14\x37\xa0\x9c\x69\x85\x40\x1b\x60\xd4\x35\x54\xae\x10\x58\x02\xc5\xf5\xd8\xa9\xb3\x25\x36\x49\xc0\xbe\x66\x05"
 				"\xa0\x84\xf0\x1d\x14\x37\xa0\x9c\x69\x85\x40\x1b\x60\xd4\x35\x54\xae\x10\x58\x02\xc5\xf5\xd8\xa9\xb3\x25\x36\x49\xc0\xbe\x66\x05"
 				"\xa0\x84\xf0\x1d\x14\x37\xa0\x9c\x69\x85\x40\x1b\x60\xd4\x35\x54\xae\x10\x58\x02\xc5\xf5\xd8\xa9\xb3\x25\x36\x49\xc0\xbe\x66\x05"
 				"\xa0\x84\xf0\x1d\x14\x37\xa0\x9c\x69\x85\x40\x1b\x60\xd4\x35\x54\xae\x10\x58\x02\xc5\xf5\xd8\xa9\xb3\x25\x36\x49\xc0\xbe\x66\x05", 128) == 0;
 
 		hashf_multi = func_multi_selector(5, ::jconf::inst()->HaveHardwareAes(), false, mineMonero);
-		hashf_multi("This is a testThis is a testThis is a testThis is a testThis is a test", 14, out, ctx);
+		hashf_multi("This is a testThis is a testThis is a testThis is a testThis is a test", 14, out, ctx, 0);
 		bResult &= memcmp(out, "\xa0\x84\xf0\x1d\x14\x37\xa0\x9c\x69\x85\x40\x1b\x60\xd4\x35\x54\xae\x10\x58\x02\xc5\xf5\xd8\xa9\xb3\x25\x36\x49\xc0\xbe\x66\x05"
 				"\xa0\x84\xf0\x1d\x14\x37\xa0\x9c\x69\x85\x40\x1b\x60\xd4\x35\x54\xae\x10\x58\x02\xc5\xf5\xd8\xa9\xb3\x25\x36\x49\xc0\xbe\x66\x05"
 				"\xa0\x84\xf0\x1d\x14\x37\xa0\x9c\x69\x85\x40\x1b\x60\xd4\x35\x54\xae\x10\x58\x02\xc5\xf5\xd8\xa9\xb3\x25\x36\x49\xc0\xbe\x66\x05"
@@ -341,20 +341,20 @@ minethd::cn_hash_fun minethd::func_selector(bool bHaveAes, bool bNoPrefetch, boo
 		 * is not defined. If one is defined there will be 4 entries.
 		 */
 #ifndef CONF_NO_MONERO
-		cryptonight_hash<MONERO_MASK, MONERO_ITER, MONERO_MEMORY, false, false>,
-		cryptonight_hash<MONERO_MASK, MONERO_ITER, MONERO_MEMORY, false, true>,
-		cryptonight_hash<MONERO_MASK, MONERO_ITER, MONERO_MEMORY, true, false>,
-		cryptonight_hash<MONERO_MASK, MONERO_ITER, MONERO_MEMORY, true, true>
+		cryptonight_hash<MONERO_MASK, MONERO_ITER, MONERO_MEMORY, false, false, true>,
+		cryptonight_hash<MONERO_MASK, MONERO_ITER, MONERO_MEMORY, false, true, true>,
+		cryptonight_hash<MONERO_MASK, MONERO_ITER, MONERO_MEMORY, true, false, true>,
+		cryptonight_hash<MONERO_MASK, MONERO_ITER, MONERO_MEMORY, true, true, true>
 #endif
 #if (!defined(CONF_NO_AEON)) && (!defined(CONF_NO_MONERO))
 		// comma will be added only if Monero and Aeon is build
 		,
 #endif
 #ifndef CONF_NO_AEON
-		cryptonight_hash<AEON_MASK, AEON_ITER, AEON_MEMORY, false, false>,
-		cryptonight_hash<AEON_MASK, AEON_ITER, AEON_MEMORY, false, true>,
-		cryptonight_hash<AEON_MASK, AEON_ITER, AEON_MEMORY, true, false>,
-		cryptonight_hash<AEON_MASK, AEON_ITER, AEON_MEMORY, true, true>
+		cryptonight_hash<AEON_MASK, AEON_ITER, AEON_MEMORY, false, false, false>,
+		cryptonight_hash<AEON_MASK, AEON_ITER, AEON_MEMORY, false, true, false>,
+		cryptonight_hash<AEON_MASK, AEON_ITER, AEON_MEMORY, true, false, false>,
+		cryptonight_hash<AEON_MASK, AEON_ITER, AEON_MEMORY, true, true, false>
 #endif
 	};
 
@@ -414,6 +414,8 @@ void minethd::work_main()
 			continue;
 		}
 
+		const uint8_t version = oWork.getVersion();
+
 		size_t nonce_ctr = 0;
 		constexpr size_t nonce_chunk = 4096; // Needs to be a power of 2
 
@@ -439,7 +441,7 @@ void minethd::work_main()
 
 			*piNonce = ++result.iNonce;
 
-			hash_fun(oWork.bWorkBlob, oWork.iWorkSize, result.bResult, ctx);
+			hash_fun(oWork.bWorkBlob, oWork.iWorkSize, result.bResult, ctx, version);
 
 			if (*piHashVal < oWork.iTarget)
 				executor::inst()->push_event(ex_event(result, oWork.iPoolId));
@@ -465,44 +467,44 @@ minethd::cn_hash_fun_multi minethd::func_multi_selector(size_t N, bool bHaveAes,
 		 * is not defined. If one is defined there will be 4*(MAX_N-1) entries.
 		 */
 #ifndef CONF_NO_MONERO
-		cryptonight_double_hash<MONERO_MASK, MONERO_ITER, MONERO_MEMORY, false, false>,
-		cryptonight_double_hash<MONERO_MASK, MONERO_ITER, MONERO_MEMORY, false, true>,
-		cryptonight_double_hash<MONERO_MASK, MONERO_ITER, MONERO_MEMORY, true, false>,
-		cryptonight_double_hash<MONERO_MASK, MONERO_ITER, MONERO_MEMORY, true, true>,
-		cryptonight_triple_hash<MONERO_MASK, MONERO_ITER, MONERO_MEMORY, false, false>,
-		cryptonight_triple_hash<MONERO_MASK, MONERO_ITER, MONERO_MEMORY, false, true>,
-		cryptonight_triple_hash<MONERO_MASK, MONERO_ITER, MONERO_MEMORY, true, false>,
-		cryptonight_triple_hash<MONERO_MASK, MONERO_ITER, MONERO_MEMORY, true, true>,
-		cryptonight_quad_hash<MONERO_MASK, MONERO_ITER, MONERO_MEMORY, false, false>,
-		cryptonight_quad_hash<MONERO_MASK, MONERO_ITER, MONERO_MEMORY, false, true>,
-		cryptonight_quad_hash<MONERO_MASK, MONERO_ITER, MONERO_MEMORY, true, false>,
-		cryptonight_quad_hash<MONERO_MASK, MONERO_ITER, MONERO_MEMORY, true, true>,
-		cryptonight_penta_hash<MONERO_MASK, MONERO_ITER, MONERO_MEMORY, false, false>,
-		cryptonight_penta_hash<MONERO_MASK, MONERO_ITER, MONERO_MEMORY, false, true>,
-		cryptonight_penta_hash<MONERO_MASK, MONERO_ITER, MONERO_MEMORY, true, false>,
-		cryptonight_penta_hash<MONERO_MASK, MONERO_ITER, MONERO_MEMORY, true, true>
+		cryptonight_double_hash<MONERO_MASK, MONERO_ITER, MONERO_MEMORY, false, false, true>,
+		cryptonight_double_hash<MONERO_MASK, MONERO_ITER, MONERO_MEMORY, false, true, true>,
+		cryptonight_double_hash<MONERO_MASK, MONERO_ITER, MONERO_MEMORY, true, false, true>,
+		cryptonight_double_hash<MONERO_MASK, MONERO_ITER, MONERO_MEMORY, true, true, true>,
+		cryptonight_triple_hash<MONERO_MASK, MONERO_ITER, MONERO_MEMORY, false, false, true>,
+		cryptonight_triple_hash<MONERO_MASK, MONERO_ITER, MONERO_MEMORY, false, true, true>,
+		cryptonight_triple_hash<MONERO_MASK, MONERO_ITER, MONERO_MEMORY, true, false, true>,
+		cryptonight_triple_hash<MONERO_MASK, MONERO_ITER, MONERO_MEMORY, true, true, true>,
+		cryptonight_quad_hash<MONERO_MASK, MONERO_ITER, MONERO_MEMORY, false, false, true>,
+		cryptonight_quad_hash<MONERO_MASK, MONERO_ITER, MONERO_MEMORY, false, true, true>,
+		cryptonight_quad_hash<MONERO_MASK, MONERO_ITER, MONERO_MEMORY, true, false, true>,
+		cryptonight_quad_hash<MONERO_MASK, MONERO_ITER, MONERO_MEMORY, true, true, true>,
+		cryptonight_penta_hash<MONERO_MASK, MONERO_ITER, MONERO_MEMORY, false, false, true>,
+		cryptonight_penta_hash<MONERO_MASK, MONERO_ITER, MONERO_MEMORY, false, true, true>,
+		cryptonight_penta_hash<MONERO_MASK, MONERO_ITER, MONERO_MEMORY, true, false, true>,
+		cryptonight_penta_hash<MONERO_MASK, MONERO_ITER, MONERO_MEMORY, true, true, true>
 #endif
 #if (!defined(CONF_NO_AEON)) && (!defined(CONF_NO_MONERO))
 		// comma will be added only if Monero and Aeon is build
 		,
 #endif
 #ifndef CONF_NO_AEON
-		cryptonight_double_hash<AEON_MASK, AEON_ITER, AEON_MEMORY, false, false>,
-		cryptonight_double_hash<AEON_MASK, AEON_ITER, AEON_MEMORY, false, true>,
-		cryptonight_double_hash<AEON_MASK, AEON_ITER, AEON_MEMORY, true, false>,
-		cryptonight_double_hash<AEON_MASK, AEON_ITER, AEON_MEMORY, true, true>,
-		cryptonight_triple_hash<AEON_MASK, AEON_ITER, AEON_MEMORY, false, false>,
-		cryptonight_triple_hash<AEON_MASK, AEON_ITER, AEON_MEMORY, false, true>,
-		cryptonight_triple_hash<AEON_MASK, AEON_ITER, AEON_MEMORY, true, false>,
-		cryptonight_triple_hash<AEON_MASK, AEON_ITER, AEON_MEMORY, true, true>,
-		cryptonight_quad_hash<AEON_MASK, AEON_ITER, AEON_MEMORY, false, false>,
-		cryptonight_quad_hash<AEON_MASK, AEON_ITER, AEON_MEMORY, false, true>,
-		cryptonight_quad_hash<AEON_MASK, AEON_ITER, AEON_MEMORY, true, false>,
-		cryptonight_quad_hash<AEON_MASK, AEON_ITER, AEON_MEMORY, true, true>,
-		cryptonight_penta_hash<AEON_MASK, AEON_ITER, AEON_MEMORY, false, false>,
-		cryptonight_penta_hash<AEON_MASK, AEON_ITER, AEON_MEMORY, false, true>,
-		cryptonight_penta_hash<AEON_MASK, AEON_ITER, AEON_MEMORY, true, false>,
-		cryptonight_penta_hash<AEON_MASK, AEON_ITER, AEON_MEMORY, true, true>
+		cryptonight_double_hash<AEON_MASK, AEON_ITER, AEON_MEMORY, false, false, false>,
+		cryptonight_double_hash<AEON_MASK, AEON_ITER, AEON_MEMORY, false, true, false>,
+		cryptonight_double_hash<AEON_MASK, AEON_ITER, AEON_MEMORY, true, false, false>,
+		cryptonight_double_hash<AEON_MASK, AEON_ITER, AEON_MEMORY, true, true, false>,
+		cryptonight_triple_hash<AEON_MASK, AEON_ITER, AEON_MEMORY, false, false, false>,
+		cryptonight_triple_hash<AEON_MASK, AEON_ITER, AEON_MEMORY, false, true, false>,
+		cryptonight_triple_hash<AEON_MASK, AEON_ITER, AEON_MEMORY, true, false, false>,
+		cryptonight_triple_hash<AEON_MASK, AEON_ITER, AEON_MEMORY, true, true, false>,
+		cryptonight_quad_hash<AEON_MASK, AEON_ITER, AEON_MEMORY, false, false, false>,
+		cryptonight_quad_hash<AEON_MASK, AEON_ITER, AEON_MEMORY, false, true, false>,
+		cryptonight_quad_hash<AEON_MASK, AEON_ITER, AEON_MEMORY, true, false, false>,
+		cryptonight_quad_hash<AEON_MASK, AEON_ITER, AEON_MEMORY, true, true, false>,
+		cryptonight_penta_hash<AEON_MASK, AEON_ITER, AEON_MEMORY, false, false, false>,
+		cryptonight_penta_hash<AEON_MASK, AEON_ITER, AEON_MEMORY, false, true, false>,
+		cryptonight_penta_hash<AEON_MASK, AEON_ITER, AEON_MEMORY, true, false, false>,
+		cryptonight_penta_hash<AEON_MASK, AEON_ITER, AEON_MEMORY, true, true, false>
 #endif
 	};
 
@@ -581,7 +583,7 @@ void minethd::multiway_work_main(cn_hash_fun_multi hash_fun_multi)
 	}
 
 	if(!oWork.bStall)
-		prep_multiway_work<N>(bWorkBlob, piNonce);
+               prep_multiway_work<N>(bWorkBlob, piNonce);
 
 	globalStates::inst().iConsumeCnt++;
 
@@ -600,6 +602,8 @@ void minethd::multiway_work_main(cn_hash_fun_multi hash_fun_multi)
 			prep_multiway_work<N>(bWorkBlob, piNonce);
 			continue;
 		}
+
+		const uint8_t version = oWork.getVersion();
 
 		constexpr uint32_t nonce_chunk = 4096;
 		int64_t nonce_ctr = 0;
@@ -628,7 +632,7 @@ void minethd::multiway_work_main(cn_hash_fun_multi hash_fun_multi)
 			for (size_t i = 0; i < N; i++)
 				*piNonce[i] = ++iNonce;
 
-			hash_fun_multi(bWorkBlob, oWork.iWorkSize, bHashOut, ctx);
+			hash_fun_multi(bWorkBlob, oWork.iWorkSize, bHashOut, ctx, version);
 
 			for (size_t i = 0; i < N; i++)
 			{

--- a/xmrstak/backend/cpu/minethd.hpp
+++ b/xmrstak/backend/cpu/minethd.hpp
@@ -21,7 +21,7 @@ public:
 	static std::vector<iBackend*> thread_starter(uint32_t threadOffset, miner_work& pWork);
 	static bool self_test();
 
-	typedef void (*cn_hash_fun)(const void*, size_t, void*, cryptonight_ctx*);
+	typedef void (*cn_hash_fun)(const void*, size_t, void*, cryptonight_ctx*, uint8_t);
 
 	static cn_hash_fun func_selector(bool bHaveAes, bool bNoPrefetch, bool mineMonero);
 	static bool thd_setaffinity(std::thread::native_handle_type h, uint64_t cpu_id);
@@ -29,7 +29,7 @@ public:
 	static cryptonight_ctx* minethd_alloc_ctx();
 
 private:
-	typedef void (*cn_hash_fun_multi)(const void*, size_t, void*, cryptonight_ctx**);
+	typedef void (*cn_hash_fun_multi)(const void*, size_t, void*, cryptonight_ctx**, uint8_t);
 	static cn_hash_fun_multi func_multi_selector(size_t N, bool bHaveAes, bool bNoPrefetch, bool mineMonero);
 
 	minethd(miner_work& pWork, size_t iNo, int iMultiway, bool no_prefetch, int64_t affinity);
@@ -38,7 +38,7 @@ private:
 	void multiway_work_main(cn_hash_fun_multi hash_fun_multi);
 
 	template<size_t N>
-	void prep_multiway_work(uint8_t *bWorkBlob, uint32_t **piNonce);
+       void prep_multiway_work(uint8_t *bWorkBlob, uint32_t **piNonce);
 
 	void work_main();
 	void double_work_main();

--- a/xmrstak/backend/miner_work.hpp
+++ b/xmrstak/backend/miner_work.hpp
@@ -74,5 +74,10 @@ namespace xmrstak
 
 			return *this;
 		}
+
+		uint8_t getVersion() const
+		{
+			return bWorkBlob[0];
+		}
 	};
 } // namepsace xmrstak

--- a/xmrstak/backend/nvidia/minethd.cpp
+++ b/xmrstak/backend/nvidia/minethd.cpp
@@ -255,6 +255,7 @@ void minethd::work_main()
 		if(oWork.bNiceHash)
 			iNonce = *(uint32_t*)(oWork.bWorkBlob + 39);
 
+		const uint8_t version = mineMonero ? oWork.getVersion() : 0;
 		while(globalStates::inst().iGlobalJobNo.load(std::memory_order_relaxed) == iJobNo)
 		{
 			//Allocate a new nonce every 16 rounds
@@ -266,9 +267,9 @@ void minethd::work_main()
 			uint32_t foundNonce[10];
 			uint32_t foundCount;
 
-			cryptonight_extra_cpu_prepare(&ctx, iNonce);
+			cryptonight_extra_cpu_prepare(&ctx, iNonce, version);
 
-			cryptonight_core_cpu_hash(&ctx, mineMonero);
+			cryptonight_core_cpu_hash(&ctx, mineMonero, version);
 
 			cryptonight_extra_cpu_final(&ctx, iNonce, oWork.iTarget, &foundCount, foundNonce);
 
@@ -283,7 +284,7 @@ void minethd::work_main()
 
 				*(uint32_t*)(bWorkBlob + 39) = foundNonce[i];
 
-				hash_fun(bWorkBlob, oWork.iWorkSize, bResult, cpu_ctx);
+				hash_fun(bWorkBlob, oWork.iWorkSize, bResult, cpu_ctx, version);
 				if ( (*((uint64_t*)(bResult + 24))) < oWork.iTarget)
 					executor::inst()->push_event(ex_event(job_result(oWork.sJobID, foundNonce[i], bResult, iThreadNo), oWork.iPoolId));
 				else

--- a/xmrstak/backend/nvidia/minethd.hpp
+++ b/xmrstak/backend/nvidia/minethd.hpp
@@ -29,7 +29,7 @@ public:
 	static bool self_test();
 
 private:
-	typedef void (*cn_hash_fun)(const void*, size_t, void*, cryptonight_ctx*);
+	typedef void (*cn_hash_fun)(const void*, size_t, void*, cryptonight_ctx*, uint8_t);
 
 	minethd(miner_work& pWork, size_t iNo, const jconf::thd_cfg& cfg);
 

--- a/xmrstak/backend/nvidia/nvcc_code/cryptonight.hpp
+++ b/xmrstak/backend/nvidia/nvcc_code/cryptonight.hpp
@@ -25,6 +25,7 @@ typedef struct {
 	uint32_t *d_ctx_key1;
 	uint32_t *d_ctx_key2;
 	uint32_t *d_ctx_text;
+	uint32_t *d_ctx_tweak1_2;
 	std::string name;
 	size_t free_device_memory;
 	size_t total_device_memory;
@@ -41,8 +42,8 @@ int cuda_get_devicecount( int* deviceCount);
 int cuda_get_deviceinfo(nvid_ctx *ctx);
 int cryptonight_extra_cpu_init(nvid_ctx *ctx);
 void cryptonight_extra_cpu_set_data( nvid_ctx* ctx, const void *data, uint32_t len);
-void cryptonight_extra_cpu_prepare(nvid_ctx* ctx, uint32_t startNonce);
+void cryptonight_extra_cpu_prepare(nvid_ctx* ctx, uint32_t startNonce, unsigned version);
 void cryptonight_extra_cpu_final(nvid_ctx* ctx, uint32_t startNonce, uint64_t target, uint32_t* rescount, uint32_t *resnonce);
 }
 
-void cryptonight_core_cpu_hash(nvid_ctx* ctx, bool mineMonero);
+void cryptonight_core_cpu_hash(nvid_ctx* ctx, bool mineMonero, unsigned version);


### PR DESCRIPTION
Monero v1 PoW changes. There was a warning about merging into master. I can update the patch for dev, but I'm not sure if that is what you want in this case. Please see [monero PR](https://github.com/monero-project/monero/pull/3253) to discuss the PoW changes.

Some implementation notes:
- I didn't "catch" how the build system was injecting an ITERATION flag until after I tested this patch. It should be easy to add a MONERO or similar macro define to remove branches in the AEON OpenCL inner loop.
- sgminer has implemented a macro'ed version for the OpenCL implementation. This is interesting because it detects the version in the CPU, then swaps out the kernel. Its not immediately clear this is the best approach because its going to vary based on what the pool provides. So it might be lots of book keeping during the fork. However, it won't branch in the inner loop. This is a little harder to implement but not terrible.
- The cuda version uses a boolean template for monero to remove branches from the aeon version.
- The cuda version could alternatively pass the input and state instead of adding another global variable, however that second process function now has to do two reads. So the alternative would remove a global write in the expansion phase but add another global read in the function containing the process loop.
- The CPU version uses a booleam template for monero to remove branches from the aeon version.
- The first tweak in the CPU version accesses the scratchpad directly after the simd write. I thought about putting that type (the 128-bit type) into a union, but it should mess with registers a bit since the tweak cannot be applied to multiple integers. So it would be messing around with simd registers vs L1 access. Perhaps you can twiddle something better.
- The second tweak modifies the stack variable in the 1 and 2 at a time implementations. For 3, 4, 5 at a time, the second tweak modifies the scratchpad directly. Alternatively, you could setup a 128-bit value where the "first" 64-bits are zero. Since zero is the identity the CPU could apply the result without smashing up the simd registers. This would require an additional 128-bit value, so I wasn't sure because it will mess with register allocations.
- It should be easy to add a template variable to remove branching from the monero version in the CPU and cuda versions, with the risk of more code generated. Possibly worth it.

Also see the PR linked above for "reference" hashes. Make sure you get my last commit if you want to verify.