### PR TITLE
Correct api.json information

### DIFF
--- a/xmrstak/misc/executor.cpp
+++ b/xmrstak/misc/executor.cpp
@@ -1223,7 +1223,7 @@ void executor::http_json_report(std::string& out)
 		if(i != 0) cn_error.append(1, ',');
 
 		snprintf(buffer, sizeof(buffer), sJsonApiConnectionError,
-			int_port(duration_cast<seconds>(vMineResults[i].time.time_since_epoch()).count()),
+			int_port(duration_cast<seconds>(vSocketLog[i].time.time_since_epoch()).count()),
 			vSocketLog[i].msg.c_str());
 		cn_error.append(buffer);
 	}


### PR DESCRIPTION

Change time point used for socket error in json report. Use correct value from socket error log vector.

Fix for issue https://github.com/fireice-uk/xmr-stak/issues/1084

----------------------------------------
Please make sure your PR is against **dev** branch. Merging PRs directly into master branch would interfere with our workflow.