### PR TITLE
reenable MACOSX travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,16 +70,15 @@ matrix:
         - CMAKE_C_COMPILER=gcc-7
         - XMRSTAK_CMAKE_FLAGS="-DCUDA_ENABLE=OFF -DOpenCL_ENABLE=OFF"
 
-#    - os: osx
-#      compiler: gcc
-#      env:
-#        - XMRSTAK_CMAKE_FLAGS="-DCUDA_ENABLE=OFF -DOpenCL_ENABLE=OFF"
+    - os: osx
+      compiler: gcc
+      env:
+        - XMRSTAK_CMAKE_FLAGS="-DCUDA_ENABLE=OFF -DOpenCL_ENABLE=OFF"
 
 before_install:
   - . CI/checkPRBranch
-  - if [ $TRAVIS_OS_NAME = osx ]; then
+  - if [ $TRAVIS_OS_NAME = osx ] ; then
       brew update;
-      brew tap homebrew/science;
     fi
   - export PATH=$CUDA_ROOT/bin:$PATH
 


### PR DESCRIPTION
- remove `brew trap science`

MACOSX travis tests was removed with #1066 to pass the CI.

- [x] do not merge before the travis tests passed