### PR TITLE
Splitting types/functions to simplify wrapper creation

### DIFF
--- a/xmrstak/backend/cpu/crypto/cryptonight.h
+++ b/xmrstak/backend/cpu/crypto/cryptonight.h
@@ -5,20 +5,10 @@
 extern "C" {
 #endif
 
+#include "cryptonight_types.h"
 #include <stddef.h>
 #include <inttypes.h>
 #include "xmrstak/backend/cryptonight.hpp"
-
-
-typedef struct {
-	uint8_t hash_state[224]; // Need only 200, explicit align
-	uint8_t* long_state;
-	uint8_t ctx_info[24]; //Use some of the extra memory for flags
-} cryptonight_ctx;
-
-typedef struct {
-	const char* warning;
-} alloc_msg;
 
 size_t cryptonight_init(size_t use_fast_mem, size_t use_mlock, alloc_msg* msg);
 cryptonight_ctx* cryptonight_alloc_ctx(size_t use_fast_mem, size_t use_mlock, alloc_msg* msg);

--- a/xmrstak/backend/cpu/crypto/cryptonight_types.h
+++ b/xmrstak/backend/cpu/crypto/cryptonight_types.h
@@ -1,0 +1,24 @@
+#ifndef __CRYPTONIGHT_TYPES_H_INCLUDED
+#define __CRYPTONIGHT_TYPES_H_INCLUDED
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <cstdint>
+
+typedef struct {
+	uint8_t hash_state[224]; // Need only 200, explicit align
+	uint8_t* long_state;
+	uint8_t ctx_info[24]; //Use some of the extra memory for flags
+} cryptonight_ctx;
+
+typedef struct {
+	const char* warning;
+} alloc_msg;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
This allows for exposing the types independently from the function declarations.
This is necessary to embed/mock xmr-stak in other projects and improves testability.


