### PR TITLE
fix autoAdjust(non hwloc)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,22 @@ matrix:
         - CMAKE_C_COMPILER=gcc-6
         - XMRSTAK_CMAKE_FLAGS="-DCUDA_ENABLE=OFF -DOpenCL_ENABLE=OFF"
 
+    # test with disabled HWLOC, MICROHTTPD, OpenSSL and no accelerators
+    - os: linux
+      compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - *default_packages
+            - gcc-6
+            - g++-6
+      env:
+        - CMAKE_CXX_COMPILER=g++-6
+        - CMAKE_C_COMPILER=gcc-6
+        - XMRSTAK_CMAKE_FLAGS="-DCUDA_ENABLE=OFF -DOpenCL_ENABLE=OFF -DHWLOC_ENABLE=OFF -DOpenSSL_ENABLE=OFF -DMICROHTTPD_ENABLE=OFF"
+
     - os: linux
       compiler: gcc
       addons:

--- a/xmrstak/backend/cpu/autoAdjust.hpp
+++ b/xmrstak/backend/cpu/autoAdjust.hpp
@@ -35,19 +35,9 @@ public:
 
 	bool printConfig()
 	{
-		size_t hashMemSizeKB;
-		size_t halfHashMemSizeKB;
 
-		if(::jconf::inst()->IsCurrencyMonero())
-		{
-			hashMemSizeKB = MONERO_MEMORY / 1024u;
-			halfHashMemSizeKB = hashMemSizeKB / 2u;
-		}
-		else
-		{
-			hashMemSizeKB = AEON_MEMORY / 1024u;
-			halfHashMemSizeKB = hashMemSizeKB / 2u;
-		}
+		const size_t hashMemSizeKB = cn_select_memory(::jconf::inst()->GetMiningAlgo()) / 1024u;
+		const size_t halfHashMemSizeKB = hashMemSizeKB / 2u;
 
 		configEditor configTpl{};
 


### PR DESCRIPTION
fix #1214, fix #1210

- remove call `IsCurrencyMonero` with `cn_select_memory`
- travis: more compile combinations 
  - add tests whith disabled dependencies
