### PR TITLE
add cli option `--noAMDCache`

### DIFF
--- a/xmrstak/backend/amd/amd_gpu/gpu.cpp
+++ b/xmrstak/backend/amd/amd_gpu/gpu.cpp
@@ -16,6 +16,7 @@
 #include "xmrstak/backend/cryptonight.hpp"
 #include "xmrstak/jconf.hpp"
 #include "xmrstak/picosha2/picosha2.hpp"
+#include "xmrstak/params.hpp"
 
 #include <stdio.h>
 #include <string.h>
@@ -393,9 +394,10 @@ size_t InitOpenCLGpu(cl_context opencl_ctx, GpuContext* ctx, const char* source_
 
 	std::string cache_file = get_home() + "/.openclcache/" + hash_hex_str + ".openclbin";
 	std::ifstream clBinFile(cache_file, std::ofstream::in | std::ofstream::binary);
-	if(!clBinFile.good())
+	if(xmrstak::params::inst().AMDCache == false || !clBinFile.good())
 	{
-		printer::inst()->print_msg(L1,"OpenCL device %u - Precompiled code %s not found. Compiling ...",ctx->deviceIdx, cache_file.c_str());
+		if(xmrstak::params::inst().AMDCache)
+			printer::inst()->print_msg(L1,"OpenCL device %u - Precompiled code %s not found. Compiling ...",ctx->deviceIdx, cache_file.c_str());
 		ctx->Program = clCreateProgramWithSource(opencl_ctx, 1, (const char**)&source_code, NULL, &ret);
 		if(ret != CL_SUCCESS)
 		{
@@ -467,29 +469,31 @@ size_t InitOpenCLGpu(cl_context opencl_ctx, GpuContext* ctx, const char* source_
 		std::vector<char*> all_programs(num_devices);
 		std::vector<std::vector<char>> program_storage;
 
-		int p_id = 0;
-		size_t mem_size = 0;
-		// create memory  structure to query all OpenCL program binaries
-		for(auto & p : all_programs)
+		if(xmrstak::params::inst().AMDCache)
 		{
-			program_storage.emplace_back(std::vector<char>(binary_sizes[p_id]));
-			all_programs[p_id] = program_storage[p_id].data();
-			mem_size += binary_sizes[p_id];
-			p_id++;
-		}
+			int p_id = 0;
+			size_t mem_size = 0;
+			// create memory  structure to query all OpenCL program binaries
+			for(auto & p : all_programs)
+			{
+				program_storage.emplace_back(std::vector<char>(binary_sizes[p_id]));
+				all_programs[p_id] = program_storage[p_id].data();
+				mem_size += binary_sizes[p_id];
+				p_id++;
+			}
 
 		if((ret = clGetProgramInfo(ctx->Program, CL_PROGRAM_BINARIES, num_devices * sizeof(char*), all_programs.data(),NULL)) != CL_SUCCESS)
-		{
-			printer::inst()->print_msg(L1,"Error %s when calling clGetProgramInfo.", err_to_str(ret));
-			return ERR_OCL_API;
-		}
+			{
+				printer::inst()->print_msg(L1,"Error %s when calling clGetProgramInfo.", err_to_str(ret));
+				return ERR_OCL_API;
+			}
 
-		std::ofstream file_stream;
-		std::cout<<get_home() + "/.openclcache/" + hash_hex_str + ".openclbin"<<std::endl;
-		file_stream.open(cache_file, std::ofstream::out | std::ofstream::binary);
-		file_stream.write(all_programs[dev_id], binary_sizes[dev_id]);
-		file_stream.close();
-		printer::inst()->print_msg(L1, "OpenCL device %u - Precompiled code stored in file %s",ctx->deviceIdx, cache_file.c_str());
+			std::ofstream file_stream;
+			file_stream.open(cache_file, std::ofstream::out | std::ofstream::binary);
+			file_stream.write(all_programs[dev_id], binary_sizes[dev_id]);
+			file_stream.close();
+			printer::inst()->print_msg(L1, "OpenCL device %u - Precompiled code stored in file %s",ctx->deviceIdx, cache_file.c_str());
+		}
 	}
 	else
 	{

--- a/xmrstak/cli/cli-miner.cpp
+++ b/xmrstak/cli/cli-miner.cpp
@@ -79,6 +79,7 @@ void help()
 #endif
 #ifndef CONF_NO_OPENCL
 	cout<<"  --noAMD                    disable the AMD miner backend"<<endl;
+	cout<<"  --noAMDCache               disable the AMD(OpenCL) cache for precompiled binaries"<<endl;
 	cout<<"  --amd FILE                 AMD backend miner config file"<<endl;
 #endif
 #ifndef CONF_NO_CUDA
@@ -448,6 +449,10 @@ int main(int argc, char *argv[])
 		else if(opName.compare("--noAMD") == 0)
 		{
 			params::inst().useAMD = false;
+		}
+		else if(opName.compare("--noAMDCache") == 0)
+		{
+			params::inst().AMDCache = false;
 		}
 		else if(opName.compare("--noNVIDIA") == 0)
 		{

--- a/xmrstak/params.hpp
+++ b/xmrstak/params.hpp
@@ -21,6 +21,7 @@ struct params
 	std::string executablePrefix;
 	std::string binaryName;
 	bool useAMD;
+	bool AMDCache;
 	bool useNVIDIA;
 	bool useCPU;
 
@@ -56,6 +57,7 @@ struct params
 		binaryName("xmr-stak"),
 		executablePrefix(""),
 		useAMD(true),
+		AMDCache(true),
 		useNVIDIA(true),
 		useCPU(true),
 		configFile("config.txt"),


### PR DESCRIPTION
allow to disable the OpenCl cache
  - useful for read only systems
  - useful for unknown errors during cache reading

can be used as workaround for #1225