### PR TITLE
Support for Aeon's POW change to CN-Lite-variant1

### DIFF
--- a/xmrstak/backend/cpu/crypto/cryptonight_aesni.h
+++ b/xmrstak/backend/cpu/crypto/cryptonight_aesni.h
@@ -444,7 +444,7 @@ void cryptonight_hash(const void* input, size_t len, void* output, cryptonight_c
 	constexpr size_t ITERATIONS = cn_select_iter<ALGO>();
 	constexpr size_t MEM = cn_select_memory<ALGO>();
 
-	if(ALGO == cryptonight_monero && len < 43)
+	if((ALGO == cryptonight_monero || ALGO == cryptonight_lite_aeon) && len < 43)
 	{
 		memset(output, 0, 32);
 		return;
@@ -453,7 +453,7 @@ void cryptonight_hash(const void* input, size_t len, void* output, cryptonight_c
 	keccak((const uint8_t *)input, len, ctx0->hash_state, 200);
 
 	uint64_t monero_const;
-	if(ALGO == cryptonight_monero)
+	if(ALGO == cryptonight_monero || ALGO == cryptonight_lite_aeon)
 	{
 		monero_const  =  *reinterpret_cast<const uint64_t*>(reinterpret_cast<const uint8_t*>(input) + 35);
 		monero_const ^=  *(reinterpret_cast<const uint64_t*>(ctx0->hash_state) + 24);
@@ -482,7 +482,7 @@ void cryptonight_hash(const void* input, size_t len, void* output, cryptonight_c
 		else
 			cx = _mm_aesenc_si128(cx, _mm_set_epi64x(ah0, al0));
 
-		if(ALGO == cryptonight_monero)
+		if(ALGO == cryptonight_monero || ALGO == cryptonight_lite_aeon)
 			cryptonight_monero_tweak((uint64_t*)&l0[idx0 & MASK], _mm_xor_si128(bx0, cx));
 		else
 			_mm_store_si128((__m128i *)&l0[idx0 & MASK], _mm_xor_si128(bx0, cx));
@@ -506,7 +506,7 @@ void cryptonight_hash(const void* input, size_t len, void* output, cryptonight_c
 			_mm_prefetch((const char*)&l0[al0 & MASK], _MM_HINT_T0);
 		ah0 += lo;
 
-		if(ALGO == cryptonight_monero)
+		if(ALGO == cryptonight_monero || ALGO == cryptonight_lite_aeon)
 			((uint64_t*)&l0[idx0 & MASK])[1] = ah0 ^ monero_const;
 		else
 			((uint64_t*)&l0[idx0 & MASK])[1] = ah0;
@@ -544,7 +544,7 @@ void cryptonight_double_hash(const void* input, size_t len, void* output, crypto
 	constexpr size_t ITERATIONS = cn_select_iter<ALGO>();
 	constexpr size_t MEM = cn_select_memory<ALGO>();
 
-	if(ALGO == cryptonight_monero && len < 43)
+	if((ALGO == cryptonight_monero || ALGO == cryptonight_lite_aeon) && len < 43)
 	{
 		memset(output, 0, 64);
 		return;
@@ -554,7 +554,7 @@ void cryptonight_double_hash(const void* input, size_t len, void* output, crypto
 	keccak((const uint8_t *)input+len, len, ctx[1]->hash_state, 200);
 
 	uint64_t monero_const_0, monero_const_1;
-	if(ALGO == cryptonight_monero)
+	if(ALGO == cryptonight_monero || ALGO == cryptonight_lite_aeon)
 	{
 		monero_const_0  =  *reinterpret_cast<const uint64_t*>(reinterpret_cast<const uint8_t*>(input) + 35);
 		monero_const_0 ^=  *(reinterpret_cast<const uint64_t*>(ctx[0]->hash_state) + 24);
@@ -592,7 +592,7 @@ void cryptonight_double_hash(const void* input, size_t len, void* output, crypto
 		else
 			cx = _mm_aesenc_si128(cx, _mm_set_epi64x(axh0, axl0));
 
-		if(ALGO == cryptonight_monero)
+		if(ALGO == cryptonight_monero || ALGO == cryptonight_lite_aeon)
 			cryptonight_monero_tweak((uint64_t*)&l0[idx0 & MASK], _mm_xor_si128(bx0, cx));
 		else
 			_mm_store_si128((__m128i *)&l0[idx0 & MASK], _mm_xor_si128(bx0, cx));
@@ -610,7 +610,7 @@ void cryptonight_double_hash(const void* input, size_t len, void* output, crypto
 		else
 			cx = _mm_aesenc_si128(cx, _mm_set_epi64x(axh1, axl1));
 
-		if(ALGO == cryptonight_monero)
+		if(ALGO == cryptonight_monero || ALGO == cryptonight_lite_aeon)
 			cryptonight_monero_tweak((uint64_t*)&l1[idx1 & MASK], _mm_xor_si128(bx1, cx));
 		else
 			_mm_store_si128((__m128i *)&l1[idx1 & MASK], _mm_xor_si128(bx1, cx));
@@ -631,7 +631,7 @@ void cryptonight_double_hash(const void* input, size_t len, void* output, crypto
 		axh0 += lo;
 		((uint64_t*)&l0[idx0 & MASK])[0] = axl0;
 
-		if(ALGO == cryptonight_monero)
+		if(ALGO == cryptonight_monero || ALGO == cryptonight_lite_aeon)
 			((uint64_t*)&l0[idx0 & MASK])[1] = axh0 ^ monero_const_0;
 		else
 			((uint64_t*)&l0[idx0 & MASK])[1] = axh0;
@@ -662,7 +662,7 @@ void cryptonight_double_hash(const void* input, size_t len, void* output, crypto
 		axh1 += lo;
 		((uint64_t*)&l1[idx1 & MASK])[0] = axl1;
 
-		if(ALGO == cryptonight_monero)
+		if(ALGO == cryptonight_monero || ALGO == cryptonight_lite_aeon)
 			((uint64_t*)&l1[idx1 & MASK])[1] = axh1 ^ monero_const_1;
 		else
 			((uint64_t*)&l1[idx1 & MASK])[1] = axh1;
@@ -709,7 +709,7 @@ void cryptonight_double_hash(const void* input, size_t len, void* output, crypto
 	else							\
 		c = _mm_aesenc_si128(c, a);			\
 	b = _mm_xor_si128(b, c);				\
-	if(ALGO == cryptonight_monero) \
+	if(ALGO == cryptonight_monero || ALGO == cryptonight_lite_aeon) \
 		cryptonight_monero_tweak((uint64_t*)ptr, b); \
 	else \
 		_mm_store_si128(ptr, b);\
@@ -724,7 +724,7 @@ void cryptonight_double_hash(const void* input, size_t len, void* output, crypto
 #define CN_STEP4(a, b, c, l, mc, ptr, idx)				\
 	lo = _umul128(idx, _mm_cvtsi128_si64(b), &hi);		\
 	a = _mm_add_epi64(a, _mm_set_epi64x(lo, hi));		\
-	if(ALGO == cryptonight_monero) \
+	if(ALGO == cryptonight_monero || ALGO == cryptonight_lite_aeon) \
 		_mm_store_si128(ptr, _mm_xor_si128(a, mc)); \
 	else \
 		_mm_store_si128(ptr, a);\
@@ -751,7 +751,7 @@ void cryptonight_triple_hash(const void* input, size_t len, void* output, crypto
 	constexpr size_t ITERATIONS = cn_select_iter<ALGO>();
 	constexpr size_t MEM = cn_select_memory<ALGO>();
 
-	if(ALGO == cryptonight_monero && len < 43)
+	if((ALGO == cryptonight_monero || ALGO == cryptonight_lite_aeon) && len < 43)
 	{
 		memset(output, 0, 32 * 3);
 		return;
@@ -845,7 +845,7 @@ void cryptonight_quad_hash(const void* input, size_t len, void* output, cryptoni
 	constexpr size_t ITERATIONS = cn_select_iter<ALGO>();
 	constexpr size_t MEM = cn_select_memory<ALGO>();
 
-	if(ALGO == cryptonight_monero && len < 43)
+	if((ALGO == cryptonight_monero || ALGO == cryptonight_lite_aeon) && len < 43)
 	{
 		memset(output, 0, 32 * 4);
 		return;
@@ -954,7 +954,7 @@ void cryptonight_penta_hash(const void* input, size_t len, void* output, crypton
 	constexpr size_t ITERATIONS = cn_select_iter<ALGO>();
 	constexpr size_t MEM = cn_select_memory<ALGO>();
 
-	if(ALGO == cryptonight_monero && len < 43)
+	if((ALGO == cryptonight_monero || ALGO == cryptonight_lite_aeon) && len < 43)
 	{
 		memset(output, 0, 32 * 5);
 		return;

--- a/xmrstak/backend/cpu/minethd.cpp
+++ b/xmrstak/backend/cpu/minethd.cpp
@@ -366,6 +366,9 @@ minethd::cn_hash_fun minethd::func_selector(bool bHaveAes, bool bNoPrefetch, xmr
 	case cryptonight_heavy:
 		algv = 3;
 		break;
+	case cryptonight_lite_aeon:
+		algv = 4;
+		break;
 	default:
 		algv = 2;
 		break;
@@ -387,7 +390,11 @@ minethd::cn_hash_fun minethd::func_selector(bool bHaveAes, bool bNoPrefetch, xmr
 		cryptonight_hash<cryptonight_heavy, false, false>,
 		cryptonight_hash<cryptonight_heavy, true, false>,
 		cryptonight_hash<cryptonight_heavy, false, true>,
-		cryptonight_hash<cryptonight_heavy, true, true>
+		cryptonight_hash<cryptonight_heavy, true, true>,
+		cryptonight_hash<cryptonight_lite_aeon, false, false>,
+		cryptonight_hash<cryptonight_lite_aeon, true, false>,
+		cryptonight_hash<cryptonight_lite_aeon, false, true>,
+		cryptonight_hash<cryptonight_lite_aeon, true, true>
 	};
 
 	std::bitset<2> digit;
@@ -463,6 +470,14 @@ void minethd::work_main()
 				hash_fun = func_selector(::jconf::inst()->HaveHardwareAes(), bNoPrefetch, cryptonight);
 		}
 
+		if(::jconf::inst()->GetMiningAlgo() == cryptonight_lite_aeon)
+		{
+			if(oWork.bWorkBlob[0] >= 7)
+				hash_fun = func_selector(::jconf::inst()->HaveHardwareAes(), bNoPrefetch, cryptonight_lite_aeon);
+			else
+				hash_fun = func_selector(::jconf::inst()->HaveHardwareAes(), bNoPrefetch, cryptonight_lite);
+		}
+
 		while(globalStates::inst().iGlobalJobNo.load(std::memory_order_relaxed) == iJobNo)
 		{
 			if ((iCount++ & 0xF) == 0) //Store stats every 16 hashes
@@ -511,6 +526,9 @@ minethd::cn_hash_fun_multi minethd::func_multi_selector(size_t N, bool bHaveAes,
 		break;
 	case cryptonight_monero:
 		algv = 0;
+		break;
+	case cryptonight_lite_aeon:
+		algv = 3;
 		break;
 	default:
 		algv = 2;
@@ -565,7 +583,23 @@ minethd::cn_hash_fun_multi minethd::func_multi_selector(size_t N, bool bHaveAes,
 		cryptonight_penta_hash<cryptonight, false, false>,
 		cryptonight_penta_hash<cryptonight, true, false>,
 		cryptonight_penta_hash<cryptonight, false, true>,
-		cryptonight_penta_hash<cryptonight, true, true>
+		cryptonight_penta_hash<cryptonight, true, true>,
+		cryptonight_double_hash<cryptonight_lite_aeon, false, false>,
+		cryptonight_double_hash<cryptonight_lite_aeon, true, false>,
+		cryptonight_double_hash<cryptonight_lite_aeon, false, true>,
+		cryptonight_double_hash<cryptonight_lite_aeon, true, true>,
+		cryptonight_triple_hash<cryptonight_lite_aeon, false, false>,
+		cryptonight_triple_hash<cryptonight_lite_aeon, true, false>,
+		cryptonight_triple_hash<cryptonight_lite_aeon, false, true>,
+		cryptonight_triple_hash<cryptonight_lite_aeon, true, true>,
+		cryptonight_quad_hash<cryptonight_lite_aeon, false, false>,
+		cryptonight_quad_hash<cryptonight_lite_aeon, true, false>,
+		cryptonight_quad_hash<cryptonight_lite_aeon, false, true>,
+		cryptonight_quad_hash<cryptonight_lite_aeon, true, true>,
+		cryptonight_penta_hash<cryptonight_lite_aeon, false, false>,
+		cryptonight_penta_hash<cryptonight_lite_aeon, true, false>,
+		cryptonight_penta_hash<cryptonight_lite_aeon, false, true>,
+		cryptonight_penta_hash<cryptonight_lite_aeon, true, true>
 	};
 
 	std::bitset<2> digit;
@@ -676,6 +710,14 @@ void minethd::multiway_work_main(cn_hash_fun_multi hash_fun_multi)
 				hash_fun_multi = func_multi_selector(N, ::jconf::inst()->HaveHardwareAes(), bNoPrefetch, cryptonight_heavy);
 			else
 				hash_fun_multi = func_multi_selector(N, ::jconf::inst()->HaveHardwareAes(), bNoPrefetch, cryptonight);
+		}
+
+		if(::jconf::inst()->GetMiningAlgo() == cryptonight_lite_aeon)
+		{
+			if(oWork.bWorkBlob[0] >= 7)
+				hash_fun_multi = func_multi_selector(N, ::jconf::inst()->HaveHardwareAes(), bNoPrefetch, cryptonight_lite_aeon);
+			else
+				hash_fun_multi = func_multi_selector(N, ::jconf::inst()->HaveHardwareAes(), bNoPrefetch, cryptonight_lite);
 		}
 
 		while (globalStates::inst().iGlobalJobNo.load(std::memory_order_relaxed) == iJobNo)

--- a/xmrstak/backend/cryptonight.hpp
+++ b/xmrstak/backend/cryptonight.hpp
@@ -9,7 +9,8 @@ enum xmrstak_algo
 	cryptonight = 1,
 	cryptonight_lite = 2,
 	cryptonight_monero = 3,
-	cryptonight_heavy = 4
+	cryptonight_heavy = 4,
+	cryptonight_lite_aeon = 5
 };
 
 // define aeon settings
@@ -40,6 +41,9 @@ inline constexpr size_t cn_select_memory<cryptonight_monero>() { return CRYPTONI
 template<>
 inline constexpr size_t cn_select_memory<cryptonight_heavy>() { return CRYPTONIGHT_HEAVY_MEMORY; }
 
+template<>
+inline constexpr size_t cn_select_memory<cryptonight_lite_aeon>() { return CRYPTONIGHT_LITE_MEMORY; }
+
 
 inline size_t cn_select_memory(xmrstak_algo algo)
 {
@@ -53,6 +57,8 @@ inline size_t cn_select_memory(xmrstak_algo algo)
 		return CRYPTONIGHT_MEMORY;
 	case cryptonight_heavy:
 		return CRYPTONIGHT_HEAVY_MEMORY;
+	case cryptonight_lite_aeon:
+		return CRYPTONIGHT_LITE_MEMORY;
 	default:
 		return 0;
 	}
@@ -73,6 +79,9 @@ inline constexpr uint32_t cn_select_mask<cryptonight_monero>() { return CRYPTONI
 template<>
 inline constexpr uint32_t cn_select_mask<cryptonight_heavy>() { return CRYPTONIGHT_HEAVY_MASK; }
 
+template<>
+inline constexpr uint32_t cn_select_mask<cryptonight_lite_aeon>() { return CRYPTONIGHT_LITE_MASK; }
+
 inline size_t cn_select_mask(xmrstak_algo algo)
 {
 	switch(algo)
@@ -85,6 +94,8 @@ inline size_t cn_select_mask(xmrstak_algo algo)
 		return CRYPTONIGHT_MASK;
 	case cryptonight_heavy:
 		return CRYPTONIGHT_HEAVY_MASK;
+	case cryptonight_lite_aeon:
+		return CRYPTONIGHT_LITE_MASK;
 	default:
 		return 0;
 	}
@@ -105,6 +116,9 @@ inline constexpr uint32_t cn_select_iter<cryptonight_monero>() { return CRYPTONI
 template<>
 inline constexpr uint32_t cn_select_iter<cryptonight_heavy>() { return CRYPTONIGHT_HEAVY_ITER; }
 
+template<>
+inline constexpr uint32_t cn_select_iter<cryptonight_lite_aeon>() { return CRYPTONIGHT_LITE_ITER; }
+
 inline size_t cn_select_iter(xmrstak_algo algo)
 {
 	switch(algo)
@@ -117,6 +131,8 @@ inline size_t cn_select_iter(xmrstak_algo algo)
 		return CRYPTONIGHT_ITER;
 	case cryptonight_heavy:
 		return CRYPTONIGHT_HEAVY_ITER;
+	case cryptonight_lite_aeon:
+		return CRYPTONIGHT_LITE_ITER;
 	default:
 		return 0;
 	}

--- a/xmrstak/jconf.cpp
+++ b/xmrstak/jconf.cpp
@@ -94,7 +94,7 @@ struct xmrstak_coin_algo
 };
 
 xmrstak_coin_algo coin_algos[] = { 
-	{ "aeon", cryptonight_lite, "mine.aeon-pool.com:5555" },
+	{ "aeon7", cryptonight_lite_aeon, "mine.aeon-pool.com:5555" },
 	{ "cryptonight", cryptonight, nullptr },
 	{ "cryptonight_lite", cryptonight_lite, nullptr },
 	{ "edollar", cryptonight, nullptr },

--- a/xmrstak/misc/executor.cpp
+++ b/xmrstak/misc/executor.cpp
@@ -571,6 +571,13 @@ void executor::ex_main()
 			pools.emplace_front(0, "donate.xmr-stak.net:4444", "", "", "", 0.0, true, false, "", true);
 		break;
 
+	case cryptonight_lite_aeon:
+		if(dev_tls)
+			pools.emplace_front(0, "donate.xmr-stak.net:7700", "", "", "", 0.0, true, true, "", true);
+		else
+			pools.emplace_front(0, "donate.xmr-stak.net:4400", "", "", "", 0.0, true, false, "", true);
+		break;
+
 	case cryptonight:
 		if(dev_tls)
 			pools.emplace_front(0, "donate.xmr-stak.net:6666", "", "", "", 0.0, true, true, "", false);

--- a/xmrstak/net/jpsock.cpp
+++ b/xmrstak/net/jpsock.cpp
@@ -644,6 +644,9 @@ bool jpsock::cmd_submit(const char* sJobId, uint32_t iNonce, const uint8_t* bRes
 		case cryptonight_monero:
 			algo_name = "cryptonight-monero";
 			break;
+		case cryptonight_lite_aeon:
+			algo_name = "cryptonight-lite-aeon";
+			break;
 		default:
 			algo_name = "unknown";
 			break;

--- a/xmrstak/pools.tpl
+++ b/xmrstak/pools.tpl
@@ -20,7 +20,7 @@ POOLCONF],
 /*
  * Currency to mine. Supported values:
  *
- *    aeon
+ *    aeon7 (use this for Aeon's new PoW)
  *    cryptonight (try this if your coin is not listed)
  *    cryptonight_lite
  *    edollar


### PR DESCRIPTION
Aeon is currently being rebased to the latest Monero codebase (https://www.reddit.com/r/Aeon/comments/861fdi/new_rebase_branch_on_top_of_moneros_current_master/), and is also following the same POW change (i.e. CryptoNight-Lite-variant1). This patch adds required changes to the CPU part only; please complete the GPU part on your side. The testnet has already forked to v7 (height 44000) where this POW is used. 

A testnet pool is set up here: http://162.210.173.150:8082/
(Patched pool code: https://github.com/stoffu/cryptonote-xmr-pool/tree/aeon)
