### PR TITLE
fix cuda architecture detection

### DIFF
--- a/xmrstak/backend/nvidia/nvcc_code/cuda_extra.cu
+++ b/xmrstak/backend/nvidia/nvcc_code/cuda_extra.cu
@@ -483,7 +483,7 @@ extern "C" int cuda_get_deviceinfo(nvid_ctx* ctx)
 		 *   with a sm_20 only compiled binary
 		 */
 		for(int i = 0; i < arch.size(); ++i)
-			if(minSupportedArch == 0 || (arch[i] >= 30 && arch[i] < minSupportedArch))
+			if(arch[i] >= 30  && (minSupportedArch == 0 || arch[i] < minSupportedArch))
 				minSupportedArch = arch[i];
 		if(minSupportedArch < 30 || gpuArch < minSupportedArch)
 		{


### PR DESCRIPTION
fix #1297

If sm_20 is mixed with other architectures the detection for the minimal supported architecture is broken.
