### PR TITLE
Repair all 'namepsace' to 'namespace' (all within comments)

### DIFF
--- a/xmrstak/backend/amd/autoAdjust.hpp
+++ b/xmrstak/backend/amd/autoAdjust.hpp
@@ -155,4 +155,4 @@ private:
 };
 
 } // namespace amd
-} // namepsace xmrstak
+} // namespace xmrstak

--- a/xmrstak/backend/backendConnector.cpp
+++ b/xmrstak/backend/backendConnector.cpp
@@ -99,4 +99,4 @@ std::vector<iBackend*>* BackendConnector::thread_starter(miner_work& pWork)
 	return pvThreads;
 }
 
-} // namepsace xmrstak
+} // namespace xmrstak

--- a/xmrstak/backend/backendConnector.hpp
+++ b/xmrstak/backend/backendConnector.hpp
@@ -18,4 +18,4 @@ namespace xmrstak
 		static bool self_test();
 	};
 
-} // namepsace xmrstak
+} // namespace xmrstak

--- a/xmrstak/backend/cpu/autoAdjust.hpp
+++ b/xmrstak/backend/cpu/autoAdjust.hpp
@@ -172,4 +172,4 @@ private:
 };
 
 } // namespace cpu
-} // namepsace xmrstak
+} // namespace xmrstak

--- a/xmrstak/backend/cpu/autoAdjustHwloc.hpp
+++ b/xmrstak/backend/cpu/autoAdjustHwloc.hpp
@@ -214,4 +214,4 @@ private:
 };
 
 } // namespace cpu
-} // namepsace xmrstak
+} // namespace xmrstak

--- a/xmrstak/backend/cpu/crypto/skein_port.h
+++ b/xmrstak/backend/cpu/crypto/skein_port.h
@@ -49,7 +49,7 @@
 								multiple of size / 8)
 
 	ptr_cast(x,size)            casts a pointer to a pointer to a
-								varaiable of length 'size' bits
+								variable of length 'size' bits
 */
 
 #define ui_type(size)               uint##size##_t

--- a/xmrstak/backend/cpu/jconf.cpp
+++ b/xmrstak/backend/cpu/jconf.cpp
@@ -259,4 +259,4 @@ bool jconf::parse_config(const char* sFilename)
 }
 
 } // namespace cpu
-} // namepsace xmrstak
+} // namespace xmrstak

--- a/xmrstak/backend/cpu/jconf.hpp
+++ b/xmrstak/backend/cpu/jconf.hpp
@@ -40,4 +40,4 @@ private:
 };
 
 } // namespace cpu
-} // namepsace xmrstak
+} // namespace xmrstak

--- a/xmrstak/backend/cpu/minethd.cpp
+++ b/xmrstak/backend/cpu/minethd.cpp
@@ -769,4 +769,4 @@ void minethd::multiway_work_main()
 }
 
 } // namespace cpu
-} // namepsace xmrstak
+} // namespace xmrstak

--- a/xmrstak/backend/cpu/minethd.hpp
+++ b/xmrstak/backend/cpu/minethd.hpp
@@ -65,4 +65,4 @@ private:
 };
 
 } // namespace cpu
-} // namepsace xmrstak
+} // namespace xmrstak

--- a/xmrstak/backend/globalStates.cpp
+++ b/xmrstak/backend/globalStates.cpp
@@ -53,4 +53,4 @@ void globalStates::switch_work(miner_work& pWork, pool_data& dat)
 	iGlobalJobNo++;
 }
 
-} // namepsace xmrstak
+} // namespace xmrstak

--- a/xmrstak/backend/globalStates.hpp
+++ b/xmrstak/backend/globalStates.hpp
@@ -55,4 +55,4 @@ private:
 	}
 };
 
-} // namepsace xmrstak
+} // namespace xmrstak

--- a/xmrstak/backend/iBackend.hpp
+++ b/xmrstak/backend/iBackend.hpp
@@ -47,4 +47,4 @@ namespace xmrstak
 		}
 	};
 
-} // namepsace xmrstak
+} // namespace xmrstak

--- a/xmrstak/backend/miner_work.hpp
+++ b/xmrstak/backend/miner_work.hpp
@@ -81,4 +81,4 @@ namespace xmrstak
 		}
 
 	};
-} // namepsace xmrstak
+} // namespace xmrstak

--- a/xmrstak/backend/nvidia/autoAdjust.hpp
+++ b/xmrstak/backend/nvidia/autoAdjust.hpp
@@ -50,7 +50,7 @@ public:
 			ctx.device_blocks = -1;
 			ctx.device_threads = -1;
 
-			// set all evice option those marked as auto (-1) to a valid value
+			// set all device option those marked as auto (-1) to a valid value
 #ifndef _WIN32
 			ctx.device_bfactor = 0;
 			ctx.device_bsleep = 0;

--- a/xmrstak/backend/nvidia/autoAdjust.hpp
+++ b/xmrstak/backend/nvidia/autoAdjust.hpp
@@ -109,4 +109,4 @@ private:
 };
 
 } // namespace nvidia
-} // namepsace xmrstak
+} // namespace xmrstak

--- a/xmrstak/backend/nvidia/jconf.hpp
+++ b/xmrstak/backend/nvidia/jconf.hpp
@@ -49,4 +49,4 @@ private:
 };
 
 } // namespace nvidia
-} // namepsace xmrstak
+} // namespace xmrstak

--- a/xmrstak/backend/nvidia/minethd.hpp
+++ b/xmrstak/backend/nvidia/minethd.hpp
@@ -60,4 +60,4 @@ private:
 };
 
 } // namespace nvidia
-} // namepsace xmrstak
+} // namespace xmrstak

--- a/xmrstak/backend/nvidia/nvcc_code/cuda_extra.cu
+++ b/xmrstak/backend/nvidia/nvcc_code/cuda_extra.cu
@@ -458,7 +458,7 @@ extern "C" int cuda_get_deviceinfo(nvid_ctx* ctx)
 #undef XMRSTAK_PP_TOSTRING1
 	std::stringstream ss(archStringList);
 
-	//transform string list sperated with `+` into a vector of integers
+	//transform string list separated with `+` into a vector of integers
 	int tmpArch;
 	while ( ss >> tmpArch )
 		arch.push_back( tmpArch );
@@ -492,7 +492,7 @@ extern "C" int cuda_get_deviceinfo(nvid_ctx* ctx)
 		}
 	}
 
-	// set all evice option those marked as auto (-1) to a valid value
+	// set all device option those marked as auto (-1) to a valid value
 	if(ctx->device_blocks == -1)
 	{
 		/* good values based of my experience

--- a/xmrstak/backend/plugin.hpp
+++ b/xmrstak/backend/plugin.hpp
@@ -109,4 +109,4 @@ struct plugin
  * */
 };
 
-} // namepsace xmrstak
+} // namespace xmrstak

--- a/xmrstak/misc/configEditor.hpp
+++ b/xmrstak/misc/configEditor.hpp
@@ -54,4 +54,4 @@ struct configEditor
 
 };
 
-} // namepsace xmrstak
+} // namespace xmrstak

--- a/xmrstak/misc/environment.hpp
+++ b/xmrstak/misc/environment.hpp
@@ -38,4 +38,4 @@ struct environment
 	params* pParams = nullptr;
 };
 
-} // namepsace xmrstak
+} // namespace xmrstak

--- a/xmrstak/misc/executor.hpp
+++ b/xmrstak/misc/executor.hpp
@@ -23,7 +23,7 @@ namespace cpu
 class minethd;
 
 } // namespace cpu
-} // namepsace xmrstak
+} // namespace xmrstak
 
 class executor
 {

--- a/xmrstak/misc/executor.hpp
+++ b/xmrstak/misc/executor.hpp
@@ -54,7 +54,7 @@ private:
 
 	inline void set_timestamp() { dev_timestamp = get_timestamp(); };
 
-	// In miliseconds, has to divide a second (1000ms) into an integer number
+	// In milliseconds, has to divide a second (1000ms) into an integer number
 	constexpr static size_t iTickTime = 500;
 
 	// Dev donation time period in seconds. 100 minutes by default.

--- a/xmrstak/misc/telemetry.cpp
+++ b/xmrstak/misc/telemetry.cpp
@@ -105,4 +105,4 @@ void telemetry::push_perf_value(size_t iThd, uint64_t iHashCount, uint64_t iTime
 	iBucketTop[iThd] = (iTop + 1) & iBucketMask;
 }
 
-} // namepsace xmrstak
+} // namespace xmrstak

--- a/xmrstak/misc/telemetry.hpp
+++ b/xmrstak/misc/telemetry.hpp
@@ -21,4 +21,4 @@ private:
 	uint64_t** ppTimestamps;
 };
 
-} // namepsace xmrstak
+} // namespace xmrstak

--- a/xmrstak/misc/utility.cpp
+++ b/xmrstak/misc/utility.cpp
@@ -18,4 +18,4 @@ namespace xmrstak
 					}
 				);
 	}
-} // namepsace xmrstak
+} // namespace xmrstak

--- a/xmrstak/misc/utility.hpp
+++ b/xmrstak/misc/utility.hpp
@@ -9,4 +9,4 @@ namespace xmrstak
 	 * @return true if both strings are equal, else false
 	 */
 	bool strcmp_i(const std::string& str1, const std::string& str2);
-} // namepsace xmrstak
+} // namespace xmrstak

--- a/xmrstak/net/msgstruct.hpp
+++ b/xmrstak/net/msgstruct.hpp
@@ -179,7 +179,7 @@ inline size_t get_timestamp()
 	return time_point_cast<seconds>(steady_clock::now()).time_since_epoch().count();
 };
 
-//Get milisecond timestamp
+//Get millisecond timestamp
 inline size_t get_timestamp_ms()
 {
 	using namespace std::chrono;

--- a/xmrstak/params.hpp
+++ b/xmrstak/params.hpp
@@ -69,4 +69,4 @@ struct params
 
 };
 
-} // namepsace xmrstak
+} // namespace xmrstak


### PR DESCRIPTION
NITPICK: Typos in comments only, changes no actual code