### PR TITLE
Add appveyor-build-artifacts

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -31,3 +31,8 @@ test_script:
   - copy C:\xmr-stak-dep\openssl\bin\* .
   - set XMRSTAK_NOWAIT=1
   - xmr-stak.exe --help --noUAC
+  - 7z a c:\xmr-stak\xmr-stak.zip *.exe *.dll
+
+artifacts:
+  - path: xmr-stak.zip
+    name: XMR-Stak


### PR DESCRIPTION
This will make it possible for users/devs to download the windows-dev-builds of xmr-stak directly from appveyor.

The artifacts will be available at https://ci.appveyor.com/project/fireice-uk/xmr-stak/build/artifacts