### PR TITLE
Update graft algorithm setting for graft fork

### DIFF
--- a/xmrstak/jconf.cpp
+++ b/xmrstak/jconf.cpp
@@ -102,7 +102,7 @@ xmrstak_coin_algo coin_algos[] = {
 	{ "cryptonight_lite", cryptonight_lite, cryptonight_lite, 0u, nullptr },
 	{ "edollar", cryptonight, cryptonight, 0u, nullptr },
 	{ "electroneum", cryptonight, cryptonight, 0u, nullptr },
-	{ "graft", cryptonight, cryptonight, 0u, nullptr },
+	{ "graft", cryptonight_monero, cryptonight, 8u, nullptr },
 	{ "haven", cryptonight_heavy, cryptonight, 2u, nullptr },
 	{ "intense", cryptonight, cryptonight, 0u, nullptr },
 	{ "karbo", cryptonight, cryptonight, 0u, nullptr },


### PR DESCRIPTION
Graft is forking soon, with updated software released yesterday, to what
will be v8 in Graft (current Graft cryptonight algorithm is graft v7).
This commit updates the `graft` algorithm to recognize the fork and
switch algorithms.

Fork annoucement:
https://www.graft.network/2018/04/12/patch-1-1-1-released-major-network-update-block-65110/
