### PR TITLE
Add PinkStarCoin v2.

### DIFF
--- a/xmrstak/jconf.cpp
+++ b/xmrstak/jconf.cpp
@@ -107,7 +107,8 @@ xmrstak::coin_selection coins[] = {
 	{ "monero7",             {cryptonight_monero, cryptonight_monero, 0u}, {cryptonight_monero, cryptonight_monero, 0u}, "pool.usxmrpool.com:3333" },
 	{ "stellite",            {cryptonight_monero, cryptonight, 3u},        {cryptonight_monero, cryptonight_monero, 0u}, nullptr },
 	{ "sumokoin",            {cryptonight_heavy, cryptonight_heavy, 0u},   {cryptonight_heavy, cryptonight_heavy, 0u},   nullptr },
-	{ "turtlecoin",          {cryptonight_lite, cryptonight_aeon, 255u},   {cryptonight_aeon, cryptonight_lite, 7u},     nullptr }
+	{ "turtlecoin",          {cryptonight_lite, cryptonight_aeon, 255u},   {cryptonight_aeon, cryptonight_lite, 7u},     nullptr },
+	{ "pinkstar",            {cryptonight_lite, cryptonight_aeon, 4u},     {cryptonight_aeon, cryptonight_lite, 4u},     nullptr }
 };
 
 constexpr size_t coin_alogo_size = (sizeof(coins)/sizeof(coins[0]));

--- a/xmrstak/pools.tpl
+++ b/xmrstak/pools.tpl
@@ -33,6 +33,7 @@ POOLCONF],
  *    monero7 (use this for Monero's new PoW)
  *    sumokoin (automatic switch with block version 3 to cryptonight_heavy)
  *    turtlecoin
+ *    pinkstar (use this for PinkStarCoin v2)
  *
  * Native algorithms which not depends on any block versions:
  *


### PR DESCRIPTION
PinkStarCoin v2 (PSTAR) uses CryptoNight Light Variant 1 with major block version of 4.