### PR TITLE
fix job consume

### DIFF
--- a/THIRD-PARTY-LICENSES
+++ b/THIRD-PARTY-LICENSES
@@ -5,7 +5,7 @@ This application bundles the following third-party software in accordance with t
 Package: Original NVidia mining code
 Authors: tsiv and KlausT
 License: GNU GPLv3
-Notes: Improvements are (c) of Xmr-Stak team
+Notes: Improvements are (c) of Xmr-Stak team team and are covered by GNU GPLv3
 
 -------------------------------------------------------------------------
 
@@ -24,6 +24,13 @@ License: MIT License and BSD License
 
 Package: PicoSHA2
 Authors: okdshin
+License: MIT License
+
+-------------------------------------------------------------------------
+
+Package: cpputil
+Authors: Will Zhang
+Source: https://github.com/willzhang4a58/cpputil
 License: MIT License
 
 -------------------------------------------------------------------------

--- a/THIRD-PARTY-LICENSES
+++ b/THIRD-PARTY-LICENSES
@@ -5,7 +5,7 @@ This application bundles the following third-party software in accordance with t
 Package: Original NVidia mining code
 Authors: tsiv and KlausT
 License: GNU GPLv3
-Notes: Improvements are (c) of Xmr-Stak team team and are covered by GNU GPLv3
+Notes: Improvements are (c) of Xmr-Stak team and are covered by GNU GPLv3
 
 -------------------------------------------------------------------------
 

--- a/xmrstak/backend/amd/minethd.hpp
+++ b/xmrstak/backend/amd/minethd.hpp
@@ -20,7 +20,6 @@ class minethd  : public iBackend
 {
 public:
 
-	static void switch_work(miner_work& pWork);
 	static std::vector<iBackend*>* thread_starter(uint32_t threadOffset, miner_work& pWork);
 	static bool init_gpus();
 
@@ -30,11 +29,9 @@ private:
 	minethd(miner_work& pWork, size_t iNo, GpuContext* ctx, const jconf::thd_cfg cfg);
 
 	void work_main();
-	void consume_work();
 
 	uint64_t iJobNo;
-
-	static miner_work oGlobalWork;
+	
 	miner_work oWork;
 
 	std::promise<void> order_fix;

--- a/xmrstak/backend/backendConnector.cpp
+++ b/xmrstak/backend/backendConnector.cpp
@@ -57,9 +57,6 @@ bool BackendConnector::self_test()
 
 std::vector<iBackend*>* BackendConnector::thread_starter(miner_work& pWork)
 {
-	globalStates::inst().iGlobalJobNo = 0;
-	globalStates::inst().iConsumeCnt = 0;
-
 
 	std::vector<iBackend*>* pvThreads = new std::vector<iBackend*>;
 

--- a/xmrstak/backend/cpu/minethd.cpp
+++ b/xmrstak/backend/cpu/minethd.cpp
@@ -347,13 +347,6 @@ std::vector<iBackend*> minethd::thread_starter(uint32_t threadOffset, miner_work
 	return pvThreads;
 }
 
-void minethd::consume_work()
-{
-	memcpy(&oWork, &globalStates::inst().inst().oGlobalWork, sizeof(miner_work));
-	iJobNo++;
-	globalStates::inst().inst().iConsumeCnt++;
-}
-
 minethd::cn_hash_fun minethd::func_selector(bool bHaveAes, bool bNoPrefetch, xmrstak_algo algo)
 {
 	// We have two independent flag bits in the functions
@@ -450,7 +443,6 @@ void minethd::work_main()
 
 	piHashVal = (uint64_t*)(result.bResult + 24);
 	piNonce = (uint32_t*)(oWork.bWorkBlob + 39);
-	globalStates::inst().inst().iConsumeCnt++;
 	result.iThreadId = iThreadNo;
 
 	uint8_t version = 0;
@@ -468,7 +460,7 @@ void minethd::work_main()
 			while (globalStates::inst().iGlobalJobNo.load(std::memory_order_relaxed) == iJobNo)
 				std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
-			consume_work();
+			globalStates::inst().consume_work(oWork, iJobNo);
 			continue;
 		}
 
@@ -524,7 +516,7 @@ void minethd::work_main()
 			std::this_thread::yield();
 		}
 
-		consume_work();
+		globalStates::inst().consume_work(oWork, iJobNo);
 	}
 
 	cryptonight_free_ctx(ctx);
@@ -773,7 +765,7 @@ void minethd::multiway_work_main()
 			while (globalStates::inst().iGlobalJobNo.load(std::memory_order_relaxed) == iJobNo)
 				std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
-			consume_work();
+			globalStates::inst().consume_work(oWork, iJobNo);
 			prep_multiway_work<N>(bWorkBlob, piNonce);
 			continue;
 		}
@@ -836,7 +828,7 @@ void minethd::multiway_work_main()
 			std::this_thread::yield();
 		}
 
-		consume_work();
+		globalStates::inst().consume_work(oWork, iJobNo);
 		prep_multiway_work<N>(bWorkBlob, piNonce);
 	}
 

--- a/xmrstak/backend/cpu/minethd.hpp
+++ b/xmrstak/backend/cpu/minethd.hpp
@@ -47,11 +47,8 @@ private:
 	void quad_work_main();
 	void penta_work_main();
 
-	void consume_work();
-
 	uint64_t iJobNo;
 
-	static miner_work oGlobalWork;
 	miner_work oWork;
 
 	std::promise<void> order_fix;

--- a/xmrstak/backend/globalStates.cpp
+++ b/xmrstak/backend/globalStates.cpp
@@ -35,17 +35,17 @@ namespace xmrstak
 
 void globalStates::consume_work( miner_work& threadWork, uint64_t& currentJobId)
 {
-	jobLock.rdlock();
+	jobLock.ReadLock();
 
 	threadWork = oGlobalWork;
 	currentJobId = iGlobalJobNo.load(std::memory_order_relaxed);
 	
-	jobLock.unlock();
+	jobLock.UnLock();
 }
 
 void globalStates::switch_work(miner_work& pWork, pool_data& dat)
 {
-	jobLock.wrlock();
+	jobLock.WriteLock();
 	
 	// this notifies all threads that the job has changed
 	iGlobalJobNo++; 
@@ -62,7 +62,7 @@ void globalStates::switch_work(miner_work& pWork, pool_data& dat)
 	dat.iSavedNonce = iGlobalNonce.exchange(dat.iSavedNonce, std::memory_order_relaxed);
 	oGlobalWork = pWork;
 	
-	jobLock.unlock();
+	jobLock.UnLock();
 }
 
 } // namespace xmrstak

--- a/xmrstak/backend/globalStates.cpp
+++ b/xmrstak/backend/globalStates.cpp
@@ -33,24 +33,75 @@
 namespace xmrstak
 {
 
+void globalStates::consume_work( miner_work& threadWork, uint64_t& currentJobId)
+{
+	/* Only the executer thread which updates the job is ever setting iConsumeCnt
+	 * to 1000. In this case each consumer must wait until the job is fully updated.
+	 */
+	uint64_t numConsumer = 0;
+
+	/* Take care that we not consume a job if the job is updated.
+	 * If we leave the loop we have increased iConsumeCnt so that
+	 * the job will not be updated until we leave the method.
+	 */
+	do{
+		numConsumer = iConsumeCnt.load(std::memory_order_relaxed);
+		if(numConsumer < 1000)
+		{
+			// register that thread try consume job data
+			numConsumer = ++iConsumeCnt;
+			if(numConsumer >= 1000)
+			{
+				iConsumeCnt--;
+				// 11 is a arbitrary chosen prime number
+				std::this_thread::sleep_for(std::chrono::milliseconds(11));
+			}
+		}
+		else
+		{
+			// an other thread is preparing a new job, 11 is a arbitrary chosen prime number
+			std::this_thread::sleep_for(std::chrono::milliseconds(11));
+		}
+	}
+	while(numConsumer >= 1000);
+
+	threadWork = oGlobalWork;
+	currentJobId = iGlobalJobNo.load(std::memory_order_relaxed);
+	
+	// signal that thread consumed work
+	iConsumeCnt--;
+}
 
 void globalStates::switch_work(miner_work& pWork, pool_data& dat)
 {
-	// iConsumeCnt is a basic lock-like polling mechanism just in case we happen to push work
-	// faster than threads can consume them. This should never happen in real life.
-	// Pool cant physically send jobs faster than every 250ms or so due to net latency.
-
-	while (iConsumeCnt.load(std::memory_order_seq_cst) < iThreadCount)
-		std::this_thread::sleep_for(std::chrono::milliseconds(100));
+	/* 1000 is used to notify that the the job will be updated as soon
+	 * as all consumer (which currently coping oGlobalWork has copied
+	 * all data)
+	 */
+	iConsumeCnt += 1000;
+	// wait until all threads which entered consume_work are finished
+	while (iConsumeCnt.load(std::memory_order_relaxed) > 1000)
+	{
+		// 7 is a arbitrary chosen prime number which is smaller than the consumer waiting time
+		std::this_thread::sleep_for(std::chrono::milliseconds(7));
+	}
+	// BEGIN CRITICAL SECTION
+	// this notifies all threads that the job has changed
+	iGlobalJobNo++; 
 
 	size_t xid = dat.pool_id;
 	dat.pool_id = pool_id;
 	pool_id = xid;
 
-	dat.iSavedNonce = iGlobalNonce.exchange(dat.iSavedNonce, std::memory_order_seq_cst);
+	/* Maybe a worker thread is updating the nonce while we read it.
+	 * In that case GPUs check the job ID after a nonce update and in the
+	 * case that it is a CPU thread we have a small chance (max 6 nonces per CPU thread)
+	 * that we recalculate a nonce after we reconnect to the current pool
+	 */
+	dat.iSavedNonce = iGlobalNonce.exchange(dat.iSavedNonce, std::memory_order_relaxed);
 	oGlobalWork = pWork;
-	iConsumeCnt.store(0, std::memory_order_seq_cst);
-	iGlobalJobNo++;
+	// END CRITICAL SECTION: allow job consume
+	iConsumeCnt -= 1000;
 }
 
 } // namespace xmrstak

--- a/xmrstak/backend/globalStates.cpp
+++ b/xmrstak/backend/globalStates.cpp
@@ -46,9 +46,6 @@ void globalStates::consume_work( miner_work& threadWork, uint64_t& currentJobId)
 void globalStates::switch_work(miner_work& pWork, pool_data& dat)
 {
 	jobLock.WriteLock();
-	
-	// this notifies all threads that the job has changed
-	iGlobalJobNo++; 
 
 	size_t xid = dat.pool_id;
 	dat.pool_id = pool_id;
@@ -61,6 +58,9 @@ void globalStates::switch_work(miner_work& pWork, pool_data& dat)
 	 */
 	dat.iSavedNonce = iGlobalNonce.exchange(dat.iSavedNonce, std::memory_order_relaxed);
 	oGlobalWork = pWork;
+
+	// this notifies all threads that the job has changed
+	iGlobalJobNo++;
 	
 	jobLock.UnLock();
 }

--- a/xmrstak/backend/globalStates.hpp
+++ b/xmrstak/backend/globalStates.hpp
@@ -4,67 +4,12 @@
 #include "xmrstak/misc/environment.hpp"
 #include "xmrstak/misc/console.hpp"
 #include "xmrstak/backend/pool_data.hpp"
+#include "xmrstak/cpputil/read_write_lock.h"
 
 #include <atomic>
-#include <condition_variable>
 
 namespace xmrstak
 {
-
-
-class RWLock {
-public:
-    RWLock() : _status(0), _waiting_readers(0), _waiting_writers(0) {}
-    RWLock(const RWLock&) = delete;
-    RWLock(RWLock&&) = delete;
-    RWLock& operator = (const RWLock&) = delete;
-    RWLock& operator = (RWLock&&) = delete;
-
-    void rdlock() {
-        std::unique_lock<std::mutex> lck(_mtx);
-        _waiting_readers += 1;
-        _read_cv.wait(lck, [&]() { return _waiting_writers == 0 && _status >= 0; });
-        _waiting_readers -= 1;
-        _status += 1;
-    }
-
-    void wrlock() {
-        std::unique_lock<std::mutex> lck(_mtx);
-        _waiting_writers += 1;
-        _write_cv.wait(lck, [&]() { return _status == 0; });
-        _waiting_writers -= 1;
-        _status = -1;
-    }
-
-    void unlock() {
-        std::unique_lock<std::mutex> lck(_mtx);
-        if (_status == -1) {
-            _status = 0;
-        } else {
-            _status -= 1;
-        }
-        if (_waiting_writers > 0) {
-            if (_status == 0) {
-                _write_cv.notify_one();
-            }
-        } else {
-            _read_cv.notify_all();
-        }
-    }
-
-private:
-    // -1    : one writer
-    // 0     : no reader and no writer
-    // n > 0 : n reader
-    int32_t _status;
-    int32_t _waiting_readers;
-    int32_t _waiting_writers;
-    std::mutex _mtx;
-    std::condition_variable _read_cv;
-    std::condition_variable _write_cv;
-};
-
-
 
 struct globalStates
 {
@@ -101,7 +46,7 @@ private:
 	{
 	}
 
-	RWLock jobLock;
+	::cpputil::RWLock jobLock;
 };
 
 } // namespace xmrstak

--- a/xmrstak/backend/globalStates.hpp
+++ b/xmrstak/backend/globalStates.hpp
@@ -6,9 +6,65 @@
 #include "xmrstak/backend/pool_data.hpp"
 
 #include <atomic>
+#include <condition_variable>
 
 namespace xmrstak
 {
+
+
+class RWLock {
+public:
+    RWLock() : _status(0), _waiting_readers(0), _waiting_writers(0) {}
+    RWLock(const RWLock&) = delete;
+    RWLock(RWLock&&) = delete;
+    RWLock& operator = (const RWLock&) = delete;
+    RWLock& operator = (RWLock&&) = delete;
+
+    void rdlock() {
+        std::unique_lock<std::mutex> lck(_mtx);
+        _waiting_readers += 1;
+        _read_cv.wait(lck, [&]() { return _waiting_writers == 0 && _status >= 0; });
+        _waiting_readers -= 1;
+        _status += 1;
+    }
+
+    void wrlock() {
+        std::unique_lock<std::mutex> lck(_mtx);
+        _waiting_writers += 1;
+        _write_cv.wait(lck, [&]() { return _status == 0; });
+        _waiting_writers -= 1;
+        _status = -1;
+    }
+
+    void unlock() {
+        std::unique_lock<std::mutex> lck(_mtx);
+        if (_status == -1) {
+            _status = 0;
+        } else {
+            _status -= 1;
+        }
+        if (_waiting_writers > 0) {
+            if (_status == 0) {
+                _write_cv.notify_one();
+            }
+        } else {
+            _read_cv.notify_all();
+        }
+    }
+
+private:
+    // -1    : one writer
+    // 0     : no reader and no writer
+    // n > 0 : n reader
+    int32_t _status;
+    int32_t _waiting_readers;
+    int32_t _waiting_writers;
+    std::mutex _mtx;
+    std::condition_variable _read_cv;
+    std::condition_variable _write_cv;
+};
+
+
 
 struct globalStates
 {
@@ -44,6 +100,8 @@ private:
 	globalStates() : iThreadCount(0), iGlobalJobNo(0), iConsumeCnt(0)
 	{
 	}
+
+	RWLock jobLock;
 };
 
 } // namespace xmrstak

--- a/xmrstak/backend/globalStates.hpp
+++ b/xmrstak/backend/globalStates.hpp
@@ -31,6 +31,8 @@ struct globalStates
 			nonce = iGlobalNonce.fetch_add(reserve_count);
 	}
 
+	void consume_work( miner_work& threadWork, uint64_t& currentJobId);
+
 	miner_work oGlobalWork;
 	std::atomic<uint64_t> iGlobalJobNo;
 	std::atomic<uint64_t> iConsumeCnt;
@@ -39,7 +41,7 @@ struct globalStates
 	size_t pool_id = invalid_pool_id;
 
 private:
-	globalStates() : iThreadCount(0)
+	globalStates() : iThreadCount(0), iGlobalJobNo(0), iConsumeCnt(0)
 	{
 	}
 };

--- a/xmrstak/backend/nvidia/minethd.cpp
+++ b/xmrstak/backend/nvidia/minethd.cpp
@@ -195,27 +195,6 @@ std::vector<iBackend*>* minethd::thread_starter(uint32_t threadOffset, miner_wor
 	return pvThreads;
 }
 
-void minethd::switch_work(miner_work& pWork)
-{
-	// iConsumeCnt is a basic lock-like polling mechanism just in case we happen to push work
-	// faster than threads can consume them. This should never happen in real life.
-	// Pool cant physically send jobs faster than every 250ms or so due to net latency.
-
-	while (globalStates::inst().iConsumeCnt.load(std::memory_order_seq_cst) < globalStates::inst().iThreadCount)
-		std::this_thread::sleep_for(std::chrono::milliseconds(100));
-
-	globalStates::inst().oGlobalWork = pWork;
-	globalStates::inst().iConsumeCnt.store(0, std::memory_order_seq_cst);
-	globalStates::inst().iGlobalJobNo++;
-}
-
-void minethd::consume_work()
-{
-	memcpy(&oWork, &globalStates::inst().oGlobalWork, sizeof(miner_work));
-	iJobNo++;
-	globalStates::inst().iConsumeCnt++;
-}
-
 void minethd::work_main()
 {
 	if(affinity >= 0) //-1 means no affinity
@@ -244,8 +223,6 @@ void minethd::work_main()
 
 	uint32_t iNonce;
 
-	globalStates::inst().iConsumeCnt++;
-
 	uint8_t version = 0;
 	size_t lastPoolId = 0;
 
@@ -261,7 +238,7 @@ void minethd::work_main()
 			while (globalStates::inst().iGlobalJobNo.load(std::memory_order_relaxed) == iJobNo)
 				std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
-			consume_work();
+			globalStates::inst().consume_work(oWork, iJobNo);
 			continue;
 		}
 		uint8_t new_version = oWork.getVersion();
@@ -299,6 +276,9 @@ void minethd::work_main()
 			{
 				globalStates::inst().calc_start_nonce(iNonce, oWork.bNiceHash, h_per_round * 16);
 			}
+			// check if the job is still valid, there is a small posibility that the job is switched
+			if(globalStates::inst().iGlobalJobNo.load(std::memory_order_relaxed) != iJobNo)
+				break;
 
 			uint32_t foundNonce[10];
 			uint32_t foundCount;
@@ -337,7 +317,7 @@ void minethd::work_main()
 			std::this_thread::yield();
 		}
 
-		consume_work();
+		globalStates::inst().consume_work(oWork, iJobNo);
 	}
 }
 

--- a/xmrstak/backend/nvidia/minethd.hpp
+++ b/xmrstak/backend/nvidia/minethd.hpp
@@ -24,7 +24,6 @@ class minethd : public iBackend
 {
 public:
 
-	static void switch_work(miner_work& pWork);
 	static std::vector<iBackend*>* thread_starter(uint32_t threadOffset, miner_work& pWork);
 	static bool self_test();
 
@@ -35,14 +34,12 @@ private:
 	void start_mining();
 
 	void work_main();
-	void consume_work();
 
 	static std::atomic<uint64_t> iGlobalJobNo;
 	static std::atomic<uint64_t> iConsumeCnt;
 	static uint64_t iThreadCount;
 	uint64_t iJobNo;
 
-	static miner_work oGlobalWork;
 	miner_work oWork;
 
 	std::promise<void> numa_promise;

--- a/xmrstak/cpputil/LICENSE.txt
+++ b/xmrstak/cpputil/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Will Zhang
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/xmrstak/cpputil/read_write_lock.h
+++ b/xmrstak/cpputil/read_write_lock.h
@@ -1,0 +1,63 @@
+#ifndef CPPUTIL_READ_WRITE_LOCK_H_
+#define CPPUTIL_READ_WRITE_LOCK_H_
+
+#include <mutex>
+#include <condition_variable>
+
+namespace cpputil {
+
+class RWLock {
+ public:
+  RWLock() : status_(0), waiting_readers_(0), waiting_writers_(0) {}
+  RWLock(const RWLock&) = delete;
+  RWLock(RWLock&&) = delete;
+  RWLock& operator = (const RWLock&) = delete;
+  RWLock& operator = (RWLock&&) = delete;
+
+  void ReadLock() {
+    std::unique_lock<std::mutex> lck(mtx_);
+    waiting_readers_ += 1;
+    read_cv_.wait(lck, [&]() { return waiting_writers_ == 0 && status_ >= 0; });
+    waiting_readers_ -= 1;
+    status_ += 1;
+  }
+
+  void WriteLock() {
+    std::unique_lock<std::mutex> lck(mtx_);
+    waiting_writers_ += 1;
+    write_cv_.wait(lck, [&]() { return status_ == 0; });
+    waiting_writers_ -= 1;
+    status_ = -1;
+  }
+
+  void UnLock() {
+    std::unique_lock<std::mutex> lck(mtx_);
+    if (status_ == -1) {
+      status_ = 0;
+    } else {
+      status_ -= 1;
+    }
+    if (waiting_writers_ > 0) {
+      if (status_ == 0) {
+        write_cv_.notify_one();
+      }
+    } else {
+      read_cv_.notify_all();
+    }
+  }
+
+ private:
+  // -1    : one writer
+  // 0     : no reader and no writer
+  // n > 0 : n reader
+  int32_t status_;
+  int32_t waiting_readers_;
+  int32_t waiting_writers_;
+  std::mutex mtx_;
+  std::condition_variable read_cv_;
+  std::condition_variable write_cv_;
+};
+
+}  // namespace cpputil
+
+#endif // CPPUTIL_READ_WRITE_LOCK_H_

--- a/xmrstak/cpputil/read_write_lock.h
+++ b/xmrstak/cpputil/read_write_lock.h
@@ -1,3 +1,26 @@
+/* MIT License
+ *
+ * Copyright (c) 2018 Will Zhang
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 #ifndef CPPUTIL_READ_WRITE_LOCK_H_
 #define CPPUTIL_READ_WRITE_LOCK_H_
 

--- a/xmrstak/cpputil/read_write_lock.h
+++ b/xmrstak/cpputil/read_write_lock.h
@@ -21,66 +21,76 @@
  * SOFTWARE.
  */
 
-#ifndef CPPUTIL_READ_WRITE_LOCK_H_
-#define CPPUTIL_READ_WRITE_LOCK_H_
+#pragma once
 
 #include <mutex>
 #include <condition_variable>
 
-namespace cpputil {
+namespace cpputil
+{
 
-class RWLock {
+class RWLock
+{
  public:
-  RWLock() : status_(0), waiting_readers_(0), waiting_writers_(0) {}
-  RWLock(const RWLock&) = delete;
-  RWLock(RWLock&&) = delete;
-  RWLock& operator = (const RWLock&) = delete;
-  RWLock& operator = (RWLock&&) = delete;
+	RWLock() : status_(0), waiting_readers_(0), waiting_writers_(0) {}
+	RWLock(const RWLock&) = delete;
+	RWLock(RWLock&&) = delete;
+	RWLock& operator = (const RWLock&) = delete;
+	RWLock& operator = (RWLock&&) = delete;
 
-  void ReadLock() {
-    std::unique_lock<std::mutex> lck(mtx_);
-    waiting_readers_ += 1;
-    read_cv_.wait(lck, [&]() { return waiting_writers_ == 0 && status_ >= 0; });
-    waiting_readers_ -= 1;
-    status_ += 1;
-  }
+	void ReadLock()
+	{
+		std::unique_lock<std::mutex> lck(mtx_);
+		waiting_readers_ += 1;
+		read_cv_.wait(lck, [&]() { return waiting_writers_ == 0 && status_ >= 0; });
+		waiting_readers_ -= 1;
+		status_ += 1;
+	}
 
-  void WriteLock() {
-    std::unique_lock<std::mutex> lck(mtx_);
-    waiting_writers_ += 1;
-    write_cv_.wait(lck, [&]() { return status_ == 0; });
-    waiting_writers_ -= 1;
-    status_ = -1;
-  }
+	void WriteLock()
+	{
+		std::unique_lock<std::mutex> lck(mtx_);
+		waiting_writers_ += 1;
+		write_cv_.wait(lck, [&]() { return status_ == 0; });
+		waiting_writers_ -= 1;
+		status_ = -1;
+	}
 
-  void UnLock() {
-    std::unique_lock<std::mutex> lck(mtx_);
-    if (status_ == -1) {
-      status_ = 0;
-    } else {
-      status_ -= 1;
-    }
-    if (waiting_writers_ > 0) {
-      if (status_ == 0) {
-        write_cv_.notify_one();
-      }
-    } else {
-      read_cv_.notify_all();
-    }
-  }
+	void UnLock()
+	{
+		std::unique_lock<std::mutex> lck(mtx_);
+		if (status_ == -1) {
+			status_ = 0;
+		} 
+		else
+		{
+			status_ -= 1;
+		}
+		if (waiting_writers_ > 0)
+		{
+			if (status_ == 0)
+			{
+				write_cv_.notify_one();
+			}
+		} 
+		else
+		{
+			read_cv_.notify_all();
+		}
+	}
 
  private:
-  // -1    : one writer
-  // 0     : no reader and no writer
-  // n > 0 : n reader
-  int32_t status_;
-  int32_t waiting_readers_;
-  int32_t waiting_writers_;
-  std::mutex mtx_;
-  std::condition_variable read_cv_;
-  std::condition_variable write_cv_;
+	/** status of the lock
+	 * -1    : one writer
+	 * 0     : no reader and no writer
+	 * n > 0 : n reader
+	 */
+	int32_t status_;
+	int32_t waiting_readers_;
+	int32_t waiting_writers_;
+	std::mutex mtx_;
+	std::condition_variable read_cv_;
+	std::condition_variable write_cv_;
 };
 
 }  // namespace cpputil
-
-#endif // CPPUTIL_READ_WRITE_LOCK_H_


### PR DESCRIPTION
~~fix #1505~~
~~fix or reduce #1337 #1222~~

- remove switch_work in all classes `minethd`
- move `consume_work` into `globalStates`
- remove the limit that each worker thread must be consume a job before we can receive a new job. 
- miner should not freeze if one GPU is hanging

In the previous implementation it was possible that a worker thread consumed and already old job if the pool is sending jobs faster than a batch of nonces is calculated. The reson is that the current implementation force that each worker must consume the oldest job in the queue before a new job can be added. On a GPU the time to process a job (a batch of nonces) before checking again if the job has changed much longer than on a CPU. A GPU needs typical ~1 sec+ (slow GPUs sometimes 10sec).

example of the PR behavior if the job is faster changed than processed:

- 1. job switch
- 2. thread consume
- 3. job switch 
- 4. job switch again
- 5. thread is finishing II. and never consume III

# Test

- [x] CPU
- [x] AMD
- [x] NVIDIA

[update:] I thought there is a race condition and deadlock in the code I changes. After discussions with @fireice-uk it looks like I was wrong. Therefore I updated the PR description.