### PR TITLE
set correct `iPoolId` for miner_work

### DIFF
--- a/xmrstak/backend/globalStates.hpp
+++ b/xmrstak/backend/globalStates.hpp
@@ -1,25 +1,14 @@
 #pragma once
 
-#include "miner_work.hpp"
+#include "xmrstak/backend/miner_work.hpp"
 #include "xmrstak/misc/environment.hpp"
 #include "xmrstak/misc/console.hpp"
+#include "xmrstak/backend/pool_data.hpp"
 
 #include <atomic>
 
-constexpr static size_t invalid_pool_id = (-1);
-
 namespace xmrstak
 {
-
-struct pool_data
-{
-	uint32_t iSavedNonce;
-	size_t   pool_id;
-
-	pool_data() : iSavedNonce(0), pool_id(invalid_pool_id)
-	{
-	}
-};
 
 struct globalStates
 {

--- a/xmrstak/backend/miner_work.hpp
+++ b/xmrstak/backend/miner_work.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "xmrstak/backend/pool_data.hpp"
+
 #include <thread>
 #include <atomic>
 #include <mutex>
@@ -20,7 +22,7 @@ namespace xmrstak
 		bool        bStall;
 		size_t      iPoolId;
 
-		miner_work() : iWorkSize(0), bNiceHash(false), bStall(true), iPoolId(0) { }
+		miner_work() : iWorkSize(0), bNiceHash(false), bStall(true), iPoolId(invalid_pool_id) { }
 
 		miner_work(const char* sJobID, const uint8_t* bWork, uint32_t iWorkSize,
 			uint64_t iTarget, bool bNiceHash, size_t iPoolId) : iWorkSize(iWorkSize),

--- a/xmrstak/backend/pool_data.hpp
+++ b/xmrstak/backend/pool_data.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+constexpr static size_t invalid_pool_id = (-1);
+
+namespace xmrstak
+{
+
+struct pool_data
+{
+	uint32_t iSavedNonce;
+	size_t   pool_id;
+
+	pool_data() : iSavedNonce(0), pool_id(invalid_pool_id)
+	{
+	}
+};
+
+} // namespace xmrstak


### PR DESCRIPTION
- initialize miner_work iPoolId in the default constructor with the invalid pool id
- move definition of `pool_data` into an own file (avoid ring includes)

If we lost the connection to the pool or at the start we set the miner_work to a default constructed work element. In this work the stalled flag is enabled and the pool id is set to default. In the previous code the id was default zero `0` which represent the dev pool. If we get the connection to a new pool or the old one after we lost the connection the previous pull in [executor.cpp:380](https://github.com/fireice-uk/xmr-stak/blob/26a5d65f12b2f19a0a3ece39a2bc64718796367b/xmrstak/misc/executor.cpp#L380) is used to store the last nonce. The nonce is wrongly passed to the dev pool.

I do not know if the old behavior is critical but it is not correct.