### PR TITLE
Alloy Support - added justification

### DIFF
--- a/xmrstak/backend/cpu/minethd.cpp
+++ b/xmrstak/backend/cpu/minethd.cpp
@@ -292,6 +292,10 @@ bool minethd::self_test()
 	else if(::jconf::inst()->GetCurrentCoinSelection().GetDescription(1).GetMiningAlgo() == cryptonight_stellite)
 	{
 	}
+		else if(::jconf::inst()->GetCurrentCoinSelection().GetDescription(1).GetMiningAlgo() == cryptonight_alloy)
+	{
+	}
+
 	for (int i = 0; i < MAX_N; i++)
 		cryptonight_free_ctx(ctx[i]);
 
@@ -384,6 +388,10 @@ minethd::cn_hash_fun minethd::func_selector(bool bHaveAes, bool bNoPrefetch, xmr
 	case cryptonight_stellite:
 		algv = 6;
 		break;
+	case cryptonight_alloy:
+		algv = 7;
+		break;
+		
 	default:
 		algv = 2;
 		break;
@@ -417,7 +425,13 @@ minethd::cn_hash_fun minethd::func_selector(bool bHaveAes, bool bNoPrefetch, xmr
 		cryptonight_hash<cryptonight_stellite, false, false>,
 		cryptonight_hash<cryptonight_stellite, true, false>,
 		cryptonight_hash<cryptonight_stellite, false, true>,
-		cryptonight_hash<cryptonight_stellite, true, true>
+		cryptonight_hash<cryptonight_stellite, true, true>,
+		
+		cryptonight_hash<cryptonight_alloy, false, false>,
+		cryptonight_hash<cryptonight_alloy, true, false>,
+		cryptonight_hash<cryptonight_alloy, false, true>,
+		cryptonight_hash<cryptonight_alloy, true, true>
+		
 	};
 
 	std::bitset<2> digit;
@@ -560,6 +574,10 @@ minethd::cn_hash_fun_multi minethd::func_multi_selector(size_t N, bool bHaveAes,
 	case cryptonight_stellite:
 		algv = 6;
 		break;
+	case cryptonight_alloy:
+		algv = 7;
+		break;
+
 	default:
 		algv = 2;
 		break;
@@ -684,7 +702,33 @@ minethd::cn_hash_fun_multi minethd::func_multi_selector(size_t N, bool bHaveAes,
 		cryptonight_penta_hash<cryptonight_stellite, true, false>,
 		cryptonight_penta_hash<cryptonight_stellite, false, true>,
 		cryptonight_penta_hash<cryptonight_stellite, true, true>,
-	};
+
+		
+		
+		cryptonight_double_hash<cryptonight_alloy, false, false>,
+		cryptonight_double_hash<cryptonight_alloy, true, false>,
+		cryptonight_double_hash<cryptonight_alloy, false, true>,
+		cryptonight_double_hash<cryptonight_alloy, true, true>,
+		cryptonight_triple_hash<cryptonight_alloy, false, false>,
+		cryptonight_triple_hash<cryptonight_alloy, true, false>,
+		cryptonight_triple_hash<cryptonight_alloy, false, true>,
+		cryptonight_triple_hash<cryptonight_alloy, true, true>,
+		cryptonight_quad_hash<cryptonight_alloy, false, false>,
+		cryptonight_quad_hash<cryptonight_alloy, true, false>,
+		cryptonight_quad_hash<cryptonight_alloy, false, true>,
+		cryptonight_quad_hash<cryptonight_alloy, true, true>,
+		cryptonight_penta_hash<cryptonight_alloy, false, false>,
+		cryptonight_penta_hash<cryptonight_alloy, true, false>,
+		cryptonight_penta_hash<cryptonight_alloy, false, true>,
+		cryptonight_penta_hash<cryptonight_alloy, true, true>
+
+		
+		
+		
+		
+		
+		
+			};
 
 	std::bitset<2> digit;
 	digit.set(0, !bHaveAes);

--- a/xmrstak/backend/cryptonight.hpp
+++ b/xmrstak/backend/cryptonight.hpp
@@ -12,7 +12,8 @@ enum xmrstak_algo
 	cryptonight_heavy = 4,
 	cryptonight_aeon = 5,
 	cryptonight_ipbc = 6, // equal to cryptonight_aeon with a small tweak in the miner code
-	cryptonight_stellite = 7 //equal to cryptonight_monero but with one tiny change
+	cryptonight_stellite = 7, //equal to cryptonight_monero but with one tiny change
+	cryptonight_alloy = 8 //equal to cryptonight_monero but with one tiny change
 };
 
 // define aeon settings
@@ -27,6 +28,10 @@ constexpr uint32_t CRYPTONIGHT_ITER = 0x80000;
 constexpr size_t CRYPTONIGHT_HEAVY_MEMORY = 4 * 1024 * 1024;
 constexpr uint32_t CRYPTONIGHT_HEAVY_MASK = 0x3FFFF0;
 constexpr uint32_t CRYPTONIGHT_HEAVY_ITER = 0x40000;
+
+constexpr uint32_t CRYPTONIGHT_ALLOY_ITER = 0x100000;
+
+
 
 template<xmrstak_algo ALGO>
 inline constexpr size_t cn_select_memory() { return 0; }
@@ -52,11 +57,15 @@ inline constexpr size_t cn_select_memory<cryptonight_ipbc>() { return CRYPTONIGH
 template<>
 inline constexpr size_t cn_select_memory<cryptonight_stellite>() { return CRYPTONIGHT_MEMORY; }
 
+template<>
+inline constexpr size_t cn_select_memory<cryptonight_alloy>() { return CRYPTONIGHT_MEMORY; }
+
 
 inline size_t cn_select_memory(xmrstak_algo algo)
 {
 	switch(algo)
 	{
+    case cryptonight_alloy:
 	case cryptonight_stellite:
 	case cryptonight_monero:
 	case cryptonight:
@@ -96,11 +105,16 @@ inline constexpr uint32_t cn_select_mask<cryptonight_ipbc>() { return CRYPTONIGH
 template<>
 inline constexpr uint32_t cn_select_mask<cryptonight_stellite>() { return CRYPTONIGHT_MASK; }
 
+template<>
+inline constexpr uint32_t cn_select_mask<cryptonight_alloy>() { return CRYPTONIGHT_MASK; }
+
+
 inline size_t cn_select_mask(xmrstak_algo algo)
 {
 	switch(algo)
 	{
 	case cryptonight_stellite:
+	case cryptonight_alloy:
 	case cryptonight_monero:
 	case cryptonight:
 		return CRYPTONIGHT_MASK;
@@ -139,10 +153,17 @@ inline constexpr uint32_t cn_select_iter<cryptonight_ipbc>() { return CRYPTONIGH
 template<>
 inline constexpr uint32_t cn_select_iter<cryptonight_stellite>() { return CRYPTONIGHT_ITER; }
 
+template<>
+inline constexpr uint32_t cn_select_iter<cryptonight_alloy>() { return CRYPTONIGHT_ALLOY_ITER; }
+
+
 inline size_t cn_select_iter(xmrstak_algo algo)
 {
 	switch(algo)
 	{
+    	case cryptonight_alloy:
+    	return CRYPTONIGHT_ALLOY_ITER;
+    	
 	case cryptonight_stellite:
 	case cryptonight_monero:
 	case cryptonight:

--- a/xmrstak/backend/nvidia/nvcc_code/cuda_core.cu
+++ b/xmrstak/backend/nvidia/nvcc_code/cuda_core.cu
@@ -515,5 +515,10 @@ void cryptonight_core_cpu_hash(nvid_ctx* ctx, xmrstak_algo miner_algo, uint32_t 
 	{
 		cryptonight_core_gpu_hash<CRYPTONIGHT_ITER, CRYPTONIGHT_MASK, CRYPTONIGHT_MEMORY/4, cryptonight_stellite>(ctx, startNonce);
 	}
+	
+	else if(miner_algo == cryptonight_alloy)
+	{
+		cryptonight_core_gpu_hash<CRYPTONIGHT_ITER, CRYPTONIGHT_MASK, CRYPTONIGHT_MEMORY/4, cryptonight_alloy>(ctx, startNonce);
+	}
 
 }

--- a/xmrstak/jconf.cpp
+++ b/xmrstak/jconf.cpp
@@ -93,6 +93,7 @@ xmrstak::coin_selection coins[] = {
 	{ "croat",               {cryptonight_monero, cryptonight, 255u},      {cryptonight_monero, cryptonight_monero, 0u}, nullptr },
 	{ "cryptonight",         {cryptonight_monero, cryptonight, 255u},      {cryptonight_monero, cryptonight_monero, 0u}, nullptr },
 	{ "cryptonight_heavy",   {cryptonight_heavy, cryptonight_heavy, 0u},   {cryptonight_heavy, cryptonight_heavy, 0u},   nullptr },
+	{ "cryptonight_alloy",   {cryptonight_alloy, cryptonight_alloy, 0u},   {cryptonight_alloy, cryptonight_alloy, 0u},   "alloypool.com:3333" },	
 	{ "cryptonight_lite",    {cryptonight_aeon, cryptonight_lite, 255u},   {cryptonight_aeon, cryptonight_lite, 7u},     nullptr },
 	{ "cryptonight_lite_v7", {cryptonight_lite, cryptonight_aeon, 255u},   {cryptonight_aeon, cryptonight_lite, 7u},     nullptr },
 	{ "cryptonight_lite_v7_xor", {cryptonight_aeon, cryptonight_ipbc, 255u}, {cryptonight_aeon, cryptonight_aeon, 255u}, nullptr },

--- a/xmrstak/net/jpsock.cpp
+++ b/xmrstak/net/jpsock.cpp
@@ -656,7 +656,12 @@ bool jpsock::cmd_submit(const char* sJobId, uint32_t iNonce, const uint8_t* bRes
 		case cryptonight_stellite:
 			algo_name = "cryptonight_v7_stellite";
 			break;
-		case cryptonight_ipbc:
+
+		case cryptonight_alloy:
+			algo_name = "cryptonight_alloy";
+			break;
+
+				case cryptonight_ipbc:
 			algo_name = "cryptonight_lite_v7_xor";
 			break;
 		case cryptonight_heavy:


### PR DESCRIPTION
Hi folks,

In regards to the hashrate requirement, we were around 8MHs pre-fork. We just recently forked and miners are switching over. Would appreciate your support so we do not need to keep distributing custom binaries to our users. 

We are currently traded on TradeOgre (https://tradeogre.com/exchange/BTC-XAO) and https://altex.exchange/markets&pair=BTC_XAO. Alloy's MainNet has been live for 5 months.



You can test with: xmr-stak --currency cryptonight_alloy -o stratum+tcp://alloypool.com:3333 -u A7cugshpEFRh8rubiTgiWrEJtJ5HbWRZZSXBZiqjbgvjKMZshSARNosJ5c9UA4fbQCVeUo51T2FEy69itj4T1mHUQBbDL7f -p x


