### PR TITLE
fix possible race condition in jpsock

### DIFF
--- a/xmrstak/net/jpsock.cpp
+++ b/xmrstak/net/jpsock.cpp
@@ -452,10 +452,12 @@ bool jpsock::process_pool_job(const opq_json_val* params)
 
 	iJobDiff = t64_to_diff(oPoolJob.iTarget);
 
-	executor::inst()->push_event(ex_event(oPoolJob, pool_id));
-
 	std::unique_lock<std::mutex> lck(job_mutex);
 	oCurrentJob = oPoolJob;
+	lck.unlock();
+	// send event after current job data are updated
+	executor::inst()->push_event(ex_event(oPoolJob, pool_id));
+	
 	return true;
 }
 


### PR DESCRIPTION
It could be that the event to update the pool job is faster processed than the current job of the pool is updated.
To avoid this the trigger for the event with a new job update is moved after the current pool job update.
