### PR TITLE
Fix condition on stellite check

### DIFF
--- a/xmrstak/backend/amd/amd_gpu/gpu.cpp
+++ b/xmrstak/backend/amd/amd_gpu/gpu.cpp
@@ -1004,7 +1004,7 @@ size_t XMRSetJob(GpuContext* ctx, uint8_t* input, size_t input_len, uint64_t tar
 		return(ERR_OCL_API);
 	}
 
-	if(miner_algo == cryptonight_monero || miner_algo == cryptonight_aeon || miner_algo == cryptonight_ipbc || cryptonight_stellite)
+	if(miner_algo == cryptonight_monero || miner_algo == cryptonight_aeon || miner_algo == cryptonight_ipbc || miner_algo == cryptonight_stellite)
 	{
 		// Input
 		if ((ret = clSetKernelArg(ctx->Kernels[kernel_storage][1], 3, sizeof(cl_mem), &ctx->InputBuffer)) != CL_SUCCESS)


### PR DESCRIPTION
When trying to use the latest `dev` branch to connect to a sumo server, I am getting:

```
[2018-05-08 12:53:32] : Pool logged in.
[2018-05-08 12:53:32] : Error CL_INVALID_ARG_INDEX when calling clSetKernelArg for kernel 1, arugment 4(input buffer).
[2018-05-08 12:53:32] : Error CL_INVALID_ARG_INDEX when calling clSetKernelArg for kernel 1, arugment 4(input buffer).
[2018-05-08 12:53:32] : Error CL_INVALID_KERNEL_ARGS when calling clEnqueueNDRangeKernel for kernel 2.
[2018-05-08 12:53:32] : Error CL_INVALID_KERNEL_ARGS when calling clEnqueueNDRangeKernel for kernel 2.
...
```
where this last error gets repeated forever.

I bisected the problem to the #1512 merge (adding stellite support), then further tracked it down to the condition for stellite missing an `==` (see the commit).