### PR TITLE
[Patch] Pool Mining Electronero via XMR-STAK as a config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ###### fireice-uk's and psychocrypt's
 # XMR-Stak - Monero/Aeon All-in-One Mining Software
 
-**XMR-Stak is ready for the POW change of Monero-v7, Aeon-v7, stellite-v4 and Sumukoin-v3**
+**XMR-Stak is ready for the POW change of Monero-v7, Aeon-v7 and Sumukoin-v3**
 
 XMR-Stak is a universal Stratum pool miner. This miner supports CPUs, AMD and NVIDIA gpus and can be used to mine the crypto currency Monero and Aeon.
 
@@ -45,14 +45,12 @@ Besides [Monero](https://getmonero.org), following coins can be mined using this
 - [Croat](https://croat.cat)
 - [Edollar](https://edollar.cash)
 - [Electroneum](https://electroneum.com)
+- [Electronero](https://electronero.org)
 - [Graft](https://www.graft.network)
 - [Haven](https://havenprotocol.com)
 - [Intense](https://intensecoin.com)
-- [IPBC](https://ipbc.io)
 - [Karbo](https://karbo.io)
-- [Masari](https://getmasari.org)
 - [Sumokoin](https://www.sumokoin.org)
-- [TurtleCoin](https://turtlecoin.lol)
 
 If your prefered coin is not listed, you can chose one of the following algorithms:
 

--- a/README.md
+++ b/README.md
@@ -49,8 +49,11 @@ Besides [Monero](https://getmonero.org), following coins can be mined using this
 - [Graft](https://www.graft.network)
 - [Haven](https://havenprotocol.com)
 - [Intense](https://intensecoin.com)
+- [IPBC](https://ipbc.io)	
 - [Karbo](https://karbo.io)
 - [Sumokoin](https://www.sumokoin.org)
+- [Masari](https://getmasari.org)	
+- [TurtleCoin](https://turtlecoin.lol)
 
 If your prefered coin is not listed, you can chose one of the following algorithms:
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ###### fireice-uk's and psychocrypt's
 # XMR-Stak - Monero/Aeon All-in-One Mining Software
 
-**XMR-Stak is ready for the POW change of Monero-v7, Aeon-v7 and Sumukoin-v3**
+**XMR-Stak is ready for the POW change of Monero-v7, Aeon-v7, stellite-v4 and Sumukoin-v3**
 
 XMR-Stak is a universal Stratum pool miner. This miner supports CPUs, AMD and NVIDIA gpus and can be used to mine the crypto currency Monero and Aeon.
 

--- a/xmrstak/jconf.cpp
+++ b/xmrstak/jconf.cpp
@@ -100,6 +100,7 @@ xmrstak::coin_selection coins[] = {
 	{ "cryptonight_v7_stellite", {cryptonight_monero, cryptonight_stellite, 255u}, {cryptonight_monero, cryptonight_monero, 255u}, nullptr },
 	{ "edollar",             {cryptonight_monero, cryptonight, 255u},      {cryptonight_monero, cryptonight_monero, 0u}, nullptr },
 	{ "electroneum",         {cryptonight_monero, cryptonight, 255u},      {cryptonight_monero, cryptonight_monero, 0u}, nullptr },
+	{ "electronero",         {cryptonight_monero, cryptonight_monero, 255u}, {cryptonight_monero, cryptonight_monero, 255u}, "donate.electronero.org:3333" },
 	{ "graft",               {cryptonight_monero, cryptonight, 8u},        {cryptonight_monero, cryptonight_monero, 0u}, nullptr },
 	{ "haven",               {cryptonight_heavy, cryptonight, 2u},         {cryptonight_heavy, cryptonight_heavy, 0u},   nullptr },
 	{ "intense",             {cryptonight_monero, cryptonight, 4u},        {cryptonight_monero, cryptonight_monero, 0u}, nullptr },

--- a/xmrstak/pools.tpl
+++ b/xmrstak/pools.tpl
@@ -25,6 +25,7 @@ POOLCONF],
  *    croat
  *    edollar
  *    electroneum
+ *    electronero
  *    graft
  *    haven
  *    intense


### PR DESCRIPTION
Tested on Ubuntu 16.04 and it's performing nicely. 
This patch applies Electronero mining support in 3 commits. 
-Update to ReadMe.md (Add Electronero.org)
-Update to jconf.cpp (Add electronero, Cryptonight_v7 POW Algo and default pool)
-Update to pools.tpl (Add electronero to display options)

I mention some details regarding Electronero in #1599 

List of Electronero Mining Pools:
https://pool.electronero.org
https://uspool.electronero.org
https://afpool.electronero.org
https://etnxpool.org
https://etnxpool.com
http://etnx.thorshammer.cc
http://etnx.leafpool.com
http://etnx.magnificentpool.com
http://newpool.pw/electronero
