### PR TITLE
remove definition of `_mm256_set_m128i`

### DIFF
--- a/xmrstak/backend/cpu/crypto/cryptonight_aesni.h
+++ b/xmrstak/backend/cpu/crypto/cryptonight_aesni.h
@@ -28,7 +28,7 @@ static inline uint64_t _umul128(uint64_t a, uint64_t b, uint64_t* hi)
 	*hi = r >> 64;
 	return (uint64_t)r;
 }
-#define _mm256_set_m128i(v0, v1)  _mm256_insertf128_si256(_mm256_castsi128_si256(v1), (v0), 1)
+
 #else
 #include <intrin.h>
 #endif // __GNUC__


### PR DESCRIPTION
This is a replacement PR for #1585, thank you @jdmedeiros for pointing us to this code snipped and providing a fix for the intel compiler.

The define of `_mm256_set_m128i` is not needed and avoid intel compiler throws a warning about it.
