### PR TITLE
Grammar fixes; mmap alloc failed error remark for Arch Linux.

### DIFF
--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -35,7 +35,7 @@ Reference: http://rybkaforum.net/cgi-bin/rybkaforum/topic_show.pl?pid=259791#pid
 
 If you set up the user rights properly ([see above](https://github.com/fireice-uk/xmr-stak/blob/master/doc/FAQ.md#selockmemoryprivilege-failed)), and your system has 4-8GB of RAM (50%+ use), there is a significant chance that there simply won't be a large enough chunk of contiguous memory because Windows is fairly bad at mitigating memory fragmentation.
 
-If that happens, disable all auto-staring applications and run the miner after a reboot.
+If that happens, disable all auto-starting applications and run the miner after a reboot.
 
 ## Error msvcp140.dll and vcruntime140.dll not available
 
@@ -46,11 +46,11 @@ Download and install this [runtime package](https://go.microsoft.com/fwlink/?Lin
 
 On Linux you will need to configure large page support and increase your ulimit -l.
 
-To set large page support, add the following lines to /etc/sysctl.conf:
+To set large page support, add the following lines to `/etc/sysctl.conf` (`/etc/sysctl.d/xmr-stak.conf` for [Arch Linux](https://www.archlinux.org/news/deprecation-of-etcsysctlconf/) and its derivatives):
 
     vm.nr_hugepages=128
 
-To increase the ulimit, add following lines to /etc/security/limits.conf:
+To increase the ulimit, add following lines to `/etc/security/limits.conf`:
 
     * soft memlock 262144
     * hard memlock 262144

--- a/doc/compile.md
+++ b/doc/compile.md
@@ -23,8 +23,8 @@ There are two easy ways to set variables for `cmake` to configure *xmr-stak*
   - edit your options
   - end the GUI by pressing the key `c`(create) and than `g`(generate)
 - set Options on the command line
-  - enable a option: `cmake .. -DNAME_OF_THE_OPTION=ON`
-  - disable a option `cmake .. -DNAME_OF_THE_OPTION=OFF`
+  - enable an option: `cmake .. -DNAME_OF_THE_OPTION=ON`
+  - disable an option `cmake .. -DNAME_OF_THE_OPTION=OFF`
   - set a value `cmake .. -DNAME_OF_THE_OPTION=value`
 
 After the configuration you need to compile the miner, follow the guide for your platform:
@@ -43,9 +43,9 @@ After the configuration you need to compile the miner, follow the guide for your
 - `CMAKE_BUILD_TYPE` set the build type
   - valid options: `Release` or `Debug`
   - you should always keep `Release` for your productive miners
-- `MICROHTTPD_ENABLE` allow to disable/enable the dependency *microhttpd*
+- `MICROHTTPD_ENABLE` allows to disable/enable the dependency *microhttpd*
   - there is no *http* interface available if option is disabled: `cmake .. -DMICROHTTPD_ENABLE=OFF`
-- `OpenSSL_ENABLE` allow to disable/enable the dependency *OpenSSL*
+- `OpenSSL_ENABLE` allows to disable/enable the dependency *OpenSSL*
   - it is not possible to connect to a *https* secured pool if option is disabled: `cmake .. -DOpenSSL_ENABLE=OFF`
 - `XMR-STAK_COMPILE` select the CPU compute architecture (default: native)
   - native means the miner binary can be used only on the system where it is compiled but will archive the highest hash rate
@@ -53,18 +53,18 @@ After the configuration you need to compile the miner, follow the guide for your
 
 ## CPU Build Options
 
-- `CPU_ENABLE` allow to disable/enable the CPU backend of the miner
-- `HWLOC_ENABLE` allow to disable/enable the dependency *hwloc*
+- `CPU_ENABLE` allows to disable/enable the CPU backend of the miner
+- `HWLOC_ENABLE` allows to disable/enable the dependency *hwloc*
   - the config suggestion is not optimal if option is disabled: `cmake .. -DHWLOC_ENABLE=OFF`
   - disabling can be reduce the miner performance
 
 ## AMD Build Options
 
-- `OpenCL_ENABLE` allow to disable/enable the AMD backend of the miner
+- `OpenCL_ENABLE` allows to disable/enable the AMD backend of the miner
 
 ## NVIDIA Build Options
 
-- `CUDA_ENABLE` allow to disable/enable the NVIDIA backend of the miner
+- `CUDA_ENABLE` allows to disable/enable the NVIDIA backend of the miner
 - `CUDA_ARCH` build for a certain compute architecture
   - this option needs a semicolon separated list
   - `cmake .. -DCUDA_ARCH=61` or `cmake .. -DCUDA_ARCH=20;61`

--- a/scripts/build_xmr-stak_docker/build_xmr-stak_docker.sh
+++ b/scripts/build_xmr-stak_docker/build_xmr-stak_docker.sh
@@ -18,7 +18,7 @@ chmod a+x cuda_*_linux-run
 ########################
 # Fedora 27
 ########################
-# CUDA is not going to work on Fedora 27 beacuse it's only support these distributions: http://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html
+# CUDA is not going to work on Fedora 27 beacuse it only supports these distributions: http://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html
 docker run --rm -it -v $PWD:/mnt fedora:27 /bin/bash -c "
 set -x ;
 dnf install -y -q cmake gcc-c++ hwloc-devel libmicrohttpd-devel libstdc++-static make openssl-devel;


### PR DESCRIPTION
Just a few grammar fixes in the docs.
Also a remark on fixing `mmap alloc failed` on Arch Linux and its derivatives. It should also be relevant for [Fedora](https://ask.fedoraproject.org/en/question/41559/has-etcsysctlconf-been-deprecated-on-fedora-20/) but I'm not its user (and didn't bother checking via VM or docker), needs confirmation from actual ones.