### PR TITLE
Buffer output in each line

### DIFF
--- a/xmrstak/config.tpl
+++ b/xmrstak/config.tpl
@@ -114,14 +114,6 @@ R"===(
 "daemon_mode" : false,
 
 /*
- * Buffered output control.
- * When running the miner through a pipe, standard output is buffered. This means that the pipe won't read
- * each output line immediately. This can cause delays when running in background.
- * Set this option to true to flush stdout after each line, so it can be read immediately.
- */
-"flush_stdout" : false,
-
-/*
  * Output file
  *
  * output_file  - This option will log all output to a file.

--- a/xmrstak/jconf.cpp
+++ b/xmrstak/jconf.cpp
@@ -52,7 +52,7 @@ using namespace rapidjson;
  */
 enum configEnum {
 	aPoolList, sCurrency, bTlsSecureAlgo, iCallTimeout, iNetRetry, iGiveUpLimit, iVerboseLevel, bPrintMotd, iAutohashTime,
-	bFlushStdout, bDaemonMode, sOutputFile, iHttpdPort, sHttpLogin, sHttpPass, bPreferIpv4, bAesOverride, sUseSlowMem
+	bDaemonMode, sOutputFile, iHttpdPort, sHttpLogin, sHttpPass, bPreferIpv4, bAesOverride, sUseSlowMem
 };
 
 struct configVal {
@@ -73,7 +73,6 @@ configVal oConfigValues[] = {
 	{ iVerboseLevel, "verbose_level", kNumberType },
 	{ bPrintMotd, "print_motd", kTrueType },
 	{ iAutohashTime, "h_print_time", kNumberType },
-	{ bFlushStdout, "flush_stdout", kTrueType},
 	{ bDaemonMode, "daemon_mode", kTrueType },
 	{ sOutputFile, "output_file", kStringType },
 	{ iHttpdPort, "httpd_port", kNumberType },
@@ -606,16 +605,6 @@ bool jconf::parse_config(const char* sFilename, const char* sFilenamePools)
 		return false;
 	}
 #endif // _WIN32
-
-	if (prv->configValues[bFlushStdout]->IsBool())
-	{
-		bool bflush = prv->configValues[bFlushStdout]->GetBool();
-		printer::inst()->set_flush_stdout(bflush);
-		if (bflush)
-		{
-			printer::inst()->print_msg(L0, "Flush stdout forced.");
-		}
-	}
 
 	std::string ctmp = GetMiningCoin();
 	std::transform(ctmp.begin(), ctmp.end(), ctmp.begin(), ::tolower);

--- a/xmrstak/misc/console.cpp
+++ b/xmrstak/misc/console.cpp
@@ -156,7 +156,6 @@ printer::printer()
 {
 	verbose_level = LINF;
 	logfile = nullptr;
-	b_flush_stdout = false;
 }
 
 bool printer::open_logfile(const char* file)
@@ -193,11 +192,7 @@ void printer::print_msg(verbosity verbose, const char* fmt, ...)
 
 	std::unique_lock<std::mutex> lck(print_mutex);
 	fputs(buf, stdout);
-
-	if (b_flush_stdout)
-	{
-		fflush(stdout);
-	}
+	fflush(stdout);
 
 	if(logfile != nullptr)
 	{
@@ -210,11 +205,7 @@ void printer::print_str(const char* str)
 {
 	std::unique_lock<std::mutex> lck(print_mutex);
 	fputs(str, stdout);
-
-	if (b_flush_stdout)
-	{
-		fflush(stdout);
-	}
+	fflush(stdout);
 
 	if(logfile != nullptr)
 	{
@@ -223,7 +214,7 @@ void printer::print_str(const char* str)
 	}
 }
 
-//Do a press any key for the windows folk. *insert any key joke here*
+// Do a press any key for the windows folk. *insert any key joke here*
 #ifdef _WIN32
 void win_exit(int code)
 {

--- a/xmrstak/misc/console.cpp
+++ b/xmrstak/misc/console.cpp
@@ -156,6 +156,8 @@ printer::printer()
 {
 	verbose_level = LINF;
 	logfile = nullptr;
+	// Windows doesn't do line buffering, so it needs to enable full buffering and manually flush the buffer
+	setvbuf(stdout, NULL, _IOFBF, BUFSIZ);
 }
 
 bool printer::open_logfile(const char* file)
@@ -193,7 +195,7 @@ void printer::print_msg(verbosity verbose, const char* fmt, ...)
     print_str(buf);
 }
 
-inline void printer::print_str(const char* str)
+void printer::print_str(const char* str)
 {
 	std::unique_lock<std::mutex> lck(print_mutex);
 	fputs(str, stdout);

--- a/xmrstak/misc/console.cpp
+++ b/xmrstak/misc/console.cpp
@@ -190,18 +190,10 @@ void printer::print_msg(verbosity verbose, const char* fmt, ...)
 	buf[bpos] = '\n';
 	buf[bpos+1] = '\0';
 
-	std::unique_lock<std::mutex> lck(print_mutex);
-	fputs(buf, stdout);
-	fflush(stdout);
-
-	if(logfile != nullptr)
-	{
-		fputs(buf, logfile);
-		fflush(logfile);
-	}
+    print_str(buf);
 }
 
-void printer::print_str(const char* str)
+inline void printer::print_str(const char* str)
 {
 	std::unique_lock<std::mutex> lck(print_mutex);
 	fputs(str, stdout);

--- a/xmrstak/misc/console.hpp
+++ b/xmrstak/misc/console.hpp
@@ -35,7 +35,6 @@ public:
 	};
 
 	inline void set_verbose_level(size_t level) { verbose_level = (verbosity)level; }
-	inline void set_flush_stdout(bool status) { b_flush_stdout = status; }
 	void print_msg(verbosity verbose, const char* fmt, ...);
 	void print_str(const char* str);
 	bool open_logfile(const char* file);
@@ -45,7 +44,6 @@ private:
 
 	std::mutex print_mutex;
 	verbosity verbose_level;
-	bool b_flush_stdout;
 	FILE* logfile;
 };
 

--- a/xmrstak/misc/console.hpp
+++ b/xmrstak/misc/console.hpp
@@ -36,7 +36,7 @@ public:
 
 	inline void set_verbose_level(size_t level) { verbose_level = (verbosity)level; }
 	void print_msg(verbosity verbose, const char* fmt, ...);
-	inline void print_str(const char* str);
+	void print_str(const char* str);
 	bool open_logfile(const char* file);
 
 private:

--- a/xmrstak/misc/console.hpp
+++ b/xmrstak/misc/console.hpp
@@ -36,7 +36,7 @@ public:
 
 	inline void set_verbose_level(size_t level) { verbose_level = (verbosity)level; }
 	void print_msg(verbosity verbose, const char* fmt, ...);
-	void print_str(const char* str);
+	inline void print_str(const char* str);
 	bool open_logfile(const char* file);
 
 private:


### PR DESCRIPTION
Right now the output is buffered with the libc default policy if `flush_stdout` is set to false. This means that if the output is the terminal (`stdout`) it will be line-buffered (except in Windows, where it's unbuffered), but if it isn't then it will be block-buffered, which becomes too slow to pipe to other program or a file. Note that when `flush_stdout` is set to true, stdout is flushed **twice** on each line.

Since those are all the possible use cases, with this PR the output will be line-buffered and flushed **only once** in all cases and therefore no config entry will be necessary.

Edit: The behaviour of Windows caught me off-guard, so I had to revert the initial modification I made, force full-buffering for everything and do the flush manually. Now it works the same across all OS. I will keep my opinions on this to myself.