### PR TITLE
adding qrl as a config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Besides [Monero](https://getmonero.org), following coins can be mined using this
 - [Haven](https://havenprotocol.com)
 - [Intense](https://intensecoin.com)
 - [Masari](https://getmasari.org)
+- [QRL](https://theqrl.org)
 - [Ryo](https://ryo-currency.com)
 - [TurtleCoin](https://turtlecoin.lol)
 

--- a/xmrstak/jconf.cpp
+++ b/xmrstak/jconf.cpp
@@ -105,6 +105,7 @@ xmrstak::coin_selection coins[] = {
 	{ "intense",             {cryptonight_monero, cryptonight, 4u},        {cryptonight_monero, cryptonight_monero, 0u}, nullptr },
 	{ "masari",              {cryptonight_masari, cryptonight_monero, 7u},   {cryptonight_monero, cryptonight_monero, 0u},nullptr },
 	{ "monero7",             {cryptonight_monero, cryptonight_monero, 0u}, {cryptonight_monero, cryptonight_monero, 0u}, "pool.usxmrpool.com:3333" },
+	{ "qrl",             	 {cryptonight_monero, cryptonight_monero, 0u}, {cryptonight_monero, cryptonight_monero, 0u}, nullptr },
 	{ "ryo",                 {cryptonight_heavy, cryptonight_heavy, 0u},   {cryptonight_heavy, cryptonight_heavy, 0u},   nullptr },
 	{ "stellite",            {cryptonight_stellite, cryptonight_monero, 4u}, {cryptonight_monero, cryptonight_monero, 0u}, nullptr },
 	{ "turtlecoin",          {cryptonight_lite, cryptonight_aeon, 255u},   {cryptonight_aeon, cryptonight_lite, 7u},     nullptr }

--- a/xmrstak/pools.tpl
+++ b/xmrstak/pools.tpl
@@ -28,6 +28,7 @@ POOLCONF],
  *    intense
  *    masari
  *    monero7 (use this for Monero's new PoW)
+ *    qrl - Quantum Resistant Ledger
  *    ryo
  *    turtlecoin
  *


### PR DESCRIPTION
Hi @psychocrypt,
This PR is linked to (https://github.com/fireice-uk/xmr-stak/pull/1549)

QRL hashpower is over 5MH/s:

You can check in some of the existing mining pools (just a couple of links as an example):
http://qrl.quantapool.com/
http://qrlmining.info/
https://qrl.herominers.com/

