### PR TITLE
telemetry: Add mutex to avoid push during recalc and other races

### DIFF
--- a/xmrstak/misc/telemetry.cpp
+++ b/xmrstak/misc/telemetry.cpp
@@ -49,6 +49,7 @@ telemetry::telemetry(size_t iThd)
 
 double telemetry::calc_telemetry_data(size_t iLastMillisec, size_t iThread)
 {
+	std::unique_lock<std::mutex> lk(mtx);
 	uint64_t iTimeNow = get_timestamp_ms();
 
 	uint64_t iEarliestHashCnt = 0;
@@ -98,6 +99,7 @@ double telemetry::calc_telemetry_data(size_t iLastMillisec, size_t iThread)
 
 void telemetry::push_perf_value(size_t iThd, uint64_t iHashCount, uint64_t iTimestamp)
 {
+	std::unique_lock<std::mutex> lk(mtx);
 	size_t iTop = iBucketTop[iThd];
 	ppHashCounts[iThd][iTop] = iHashCount;
 	ppTimestamps[iThd][iTop] = iTimestamp;

--- a/xmrstak/misc/telemetry.hpp
+++ b/xmrstak/misc/telemetry.hpp
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <cstring>
+#include <mutex>
 
 namespace xmrstak
 {
@@ -14,6 +15,7 @@ public:
 	double calc_telemetry_data(size_t iLastMillisec, size_t iThread);
 
 private:
+	mutable std::mutex mtx;
 	constexpr static size_t iBucketSize = 2 << 11; //Power of 2 to simplify calculations
 	constexpr static size_t iBucketMask = iBucketSize - 1;
 	uint32_t* iBucketTop;


### PR DESCRIPTION
Add simple locking to telemetry class, since both push and calc methods modify the data buckets and pointers,  this avoids race conditions and bucket corruption.

Hoping this solves occasional "missing stats" or inaccuracy that could not be tracked down to anything but "thread timing mystery".  It does seem to standardize my hashrates as shown which I take to mean it's more accurate.

Regardless it doesn't seem to hurt.