### PR TITLE
fix invalid shares

### DIFF
--- a/xmrstak/backend/amd/amd_gpu/opencl/cryptonight.cl
+++ b/xmrstak/backend/amd/amd_gpu/opencl/cryptonight.cl
@@ -1221,7 +1221,7 @@ __kernel void Groestl(__global ulong *states, __global uint *BranchBuf, __global
 		#pragma unroll 4
 		for(uint i = 0; i < 4; ++i)
 		{
-			ulong H[8], M[8];
+			volatile ulong H[8], M[8];
 
 			if(i < 3)
 			{


### PR DESCRIPTION
With rocm we fighted very long with invalid shares. This is now solved with rocm 1.9 and
this tiny fix.
It is not fully clear where a memory optimization is kicking in and break the kernel `Groestl` if the variables `M` and `H` are not `volatile`.
The performance ill not change with this fix.

The fix is tested with rocm 1.9 with a VEGA64 and a RX570
