### PR TITLE
Fix two new warnings within new code

### DIFF
--- a/xmrstak/backend/amd/amd_gpu/gpu.cpp
+++ b/xmrstak/backend/amd/amd_gpu/gpu.cpp
@@ -377,7 +377,7 @@ size_t InitOpenCLGpu(cl_context opencl_ctx, GpuContext* ctx, const char* source_
 	}
 
 	std::vector<char> openCLDriverVer(1024);
-	if(ret = clGetDeviceInfo(ctx->DeviceID, CL_DRIVER_VERSION, openCLDriverVer.size(), openCLDriverVer.data(), NULL) != CL_SUCCESS)
+	if((ret = clGetDeviceInfo(ctx->DeviceID, CL_DRIVER_VERSION, openCLDriverVer.size(), openCLDriverVer.data(), NULL)) != CL_SUCCESS)
 	{
 		printer::inst()->print_msg(L1,"WARNING: %s when calling clGetDeviceInfo to get CL_DRIVER_VERSION for device %u.", err_to_str(ret),ctx->deviceIdx );
 		return ERR_OCL_API;

--- a/xmrstak/backend/cpu/minethd.cpp
+++ b/xmrstak/backend/cpu/minethd.cpp
@@ -458,18 +458,19 @@ std::vector<iBackend*> minethd::thread_starter(uint32_t threadOffset, miner_work
 static std::string getAsmName(const uint32_t num_hashes)
 {
 	std::string asm_type = "off";
-	if(num_hashes == 0)
-		return asm_type;
-
-	auto cpu_model = getModel();
-
-	if(cpu_model.avx && cpu_model.aes)
+	if(num_hashes != 0)
 	{
-		if(cpu_model.type_name.find("Intel") != std::string::npos)
-			asm_type = "intel_avx";
-		else if(cpu_model.type_name.find("AMD") != std::string::npos && num_hashes == 1)
-			asm_type = "amd_avx";
+		auto cpu_model = getModel();
+
+		if(cpu_model.avx && cpu_model.aes)
+		{
+			if(cpu_model.type_name.find("Intel") != std::string::npos)
+				asm_type = "intel_avx";
+			else if(cpu_model.type_name.find("AMD") != std::string::npos && num_hashes == 1)
+				asm_type = "amd_avx";
+		}
 	}
+	return asm_type;
 }
 
 template<size_t N>


### PR DESCRIPTION
Compilers complain about these two spots in new code

The cpu fix was to make sure the new function hits return no matter what happens

The fix in amd code just applies the same as the if statement above the new one, simply missing "insurance" parenthesis

```
[ 46%] Building CXX object CMakeFiles/xmr-stak-backend.dir/xmrstak/backend/cpu/minethd.cpp.o
/usr/src/xmr-stak/xmrstak/backend/cpu/minethd.cpp:473:1: warning: control may reach end of non-void function [-Wreturn-type]
}
^
1 warning generated.
```

```
[ 92%] Building CXX object CMakeFiles/xmrstak_opencl_backend.dir/xmrstak/backend/amd/amd_gpu/gpu.cpp.o
/usr/src/xmr-stak/xmrstak/backend/amd/amd_gpu/gpu.cpp:380:9: warning: using the result of an assignment as a condition without parentheses [-Wparentheses]
        if(ret = clGetDeviceInfo(ctx->DeviceID, CL_DRIVER_VERSION, openCLDriverVer.size(), openCLDriverVer.data(), NULL) != CL_SUCCESS)
           ~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/src/xmr-stak/xmrstak/backend/amd/amd_gpu/gpu.cpp:380:9: note: place parentheses around the assignment to silence this warning
        if(ret = clGetDeviceInfo(ctx->DeviceID, CL_DRIVER_VERSION, openCLDriverVer.size(), openCLDriverVer.data(), NULL) != CL_SUCCESS)
               ^
           (                                                                                                                          )
/usr/src/xmr-stak/xmrstak/backend/amd/amd_gpu/gpu.cpp:380:9: note: use '==' to turn this assignment into an equality comparison
        if(ret = clGetDeviceInfo(ctx->DeviceID, CL_DRIVER_VERSION, openCLDriverVer.size(), openCLDriverVer.data(), NULL) != CL_SUCCESS)
               ^
               ==
1 warning generated.
```