### PR TITLE
fix access uninitialized value

### DIFF
--- a/xmrstak/misc/coinDescription.hpp
+++ b/xmrstak/misc/coinDescription.hpp
@@ -10,9 +10,9 @@ namespace xmrstak
 {
 	struct coinDescription
 	{
-		xmrstak_algo algo;
-		xmrstak_algo algo_root;
-		uint8_t fork_version;
+		xmrstak_algo algo = xmrstak_algo::invalid_algo;
+		xmrstak_algo algo_root = xmrstak_algo::invalid_algo;
+		uint8_t fork_version = 0u;
 
 		coinDescription() = default;
 


### PR DESCRIPTION
fix #1906

If the currency provided by the user is not known by the miner we access an uninitialized value.

Add default values for member of `coinDescription`.
