### PR TITLE
Add warnings for invalid results from CUDA and OpenCL

### DIFF
--- a/xmrstak/backend/amd/minethd.cpp
+++ b/xmrstak/backend/amd/minethd.cpp
@@ -260,9 +260,14 @@ void minethd::work_main()
 
 				hash_fun(bWorkBlob, oWork.iWorkSize, bResult, &cpu_ctx);
 				if ( (*((uint64_t*)(bResult + 24))) < oWork.iTarget)
+				{
 					executor::inst()->push_event(ex_event(job_result(oWork.sJobID, results[i], bResult, iThreadNo, miner_algo), oWork.iPoolId));
+				}
 				else
+				{
+					printer::inst()->print_msg(L0, "AMD Result Invalid");
 					executor::inst()->push_event(ex_event("AMD Invalid Result", pGpuCtx->deviceIdx, oWork.iPoolId));
+				}
 			}
 
 			iCount += pGpuCtx->rawIntensity;

--- a/xmrstak/backend/nvidia/minethd.cpp
+++ b/xmrstak/backend/nvidia/minethd.cpp
@@ -309,9 +309,14 @@ void minethd::work_main()
 
 				hash_fun(bWorkBlob, oWork.iWorkSize, bResult, &cpu_ctx);
 				if ( (*((uint64_t*)(bResult + 24))) < oWork.iTarget)
+				{
 					executor::inst()->push_event(ex_event(job_result(oWork.sJobID, foundNonce[i], bResult, iThreadNo, miner_algo), oWork.iPoolId));
+				}
 				else
+				{
+					printer::inst()->print_msg(L0, "NVIDIA Result Invalid");
 					executor::inst()->push_event(ex_event("NVIDIA Invalid Result", ctx.device_id, oWork.iPoolId));
+				}
 			}
 
 			iCount += h_per_round;


### PR DESCRIPTION
OpenCL and CUDA is generating hidden invalids, add warnings to make them visible. (Especially noticeable with newer AMD drivers where most results are invalids)