### PR TITLE
fix AMD driver 14

### DIFF
--- a/xmrstak/backend/amd/amd_gpu/opencl/fast_int_math_v2.cl
+++ b/xmrstak/backend/amd/amd_gpu/opencl/fast_int_math_v2.cl
@@ -79,8 +79,10 @@ inline uint2 fast_div_v2(const __local uint *RCP, ulong a, uint b)
 	 * https://github.com/fireice-uk/xmr-stak/issues/1922
 	 * This is a workaround for the broken compiler.
 	 */
-	const long xx = k - a;
-	((uint*)&q)[1] = (xx < 0) ? 1U : 0U;
+	 ulong whyAMDwhy;
+	((uint*)&whyAMDwhy)[0] = as_uint2(k).s0;
+	((uint*)&whyAMDwhy)[1] = as_uint2(k).s1;
+	((uint*)&q)[1] = (whyAMDwhy < a) ? 1U : 0U;
 #else
 	((uint*)&q)[1] = (k < a) ? 1U : 0U;
 #endif


### PR DESCRIPTION
Fix the fix from #1945. The initial fix produces invalid results.

- [x] Tested with NVIDIA OpenCL
- [x] tested with AMD Driver 1445.5 (WINDOWS) and old HD6990