### PR TITLE
Update for upcoming Graft CNv2 fork

### DIFF
--- a/xmrstak/jconf.cpp
+++ b/xmrstak/jconf.cpp
@@ -101,7 +101,7 @@ xmrstak::coin_selection coins[] = {
 	{ "cryptonight_v7",      {cryptonight_monero_v8, cryptonight_monero, 255u},   {cryptonight_monero_v8, cryptonight_monero, 8u}, nullptr },
 	{ "cryptonight_v8",      {cryptonight_monero, cryptonight_monero_v8, 255u},   {cryptonight_monero_v8, cryptonight_monero, 8u}, nullptr },
 	{ "cryptonight_v7_stellite", {cryptonight_monero_v8, cryptonight_stellite, 255u}, {cryptonight_monero_v8, cryptonight_monero_v8, 0u}, nullptr },
-	{ "graft",               {cryptonight_monero_v8, cryptonight_monero, 255u},   {cryptonight_monero_v8, cryptonight_monero, 8u}, nullptr },
+	{ "graft",               {cryptonight_monero_v8, cryptonight_monero, 11u},    {cryptonight_monero_v8, cryptonight_monero, 8u}, nullptr },
 	{ "haven",               {cryptonight_heavy, cryptonight_haven, 255u},        {cryptonight_heavy, cryptonight_heavy, 0u},   nullptr },
 	{ "intense",             {cryptonight_monero_v8, cryptonight_monero, 255u},   {cryptonight_monero_v8, cryptonight_monero, 8u}, nullptr },
 	{ "masari",              {cryptonight_monero_v8, cryptonight_masari, 255u},   {cryptonight_monero_v8, cryptonight_monero_v8, 0u},nullptr },


### PR DESCRIPTION
Graft is forking to CNv2 (or "v8") in [just over a week](https://www.graft.network/2018/10/23/graft-anti-asic-major-network-update-1-5-on-october-31-2018/) with major version 11.  This PR updates the `graft` coin setting to recognize it.