### PR TITLE
Patches to enable compilation under Windows with MSYS2 or Cygwin64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,5 @@
-project(xmr-stak)
-
 cmake_minimum_required(VERSION 3.4.0)
+project(xmr-stak)
 
 # enforce C++11
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -444,8 +443,13 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 endif()
 
 if(${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
-    set(CMAKE_CXX_FLAGS "-Wl,-z,noexecstack ${CMAKE_CXX_FLAGS}")
-    set(CMAKE_C_FLAGS "-Wl,-z,noexecstack ${CMAKE_C_FLAGS}")
+    if(CMAKE_RC_COMPILER MATCHES "windres") # lame hack to detect Cygwin
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -U_WIN32 -U__USE_W32_SOCKETS -D_POSIX_C_SOURCE=200112")
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -U_WIN32 -U__USE_W32_SOCKETS -D_POSIX_C_SOURCE=200112")
+    else()
+        set(CMAKE_CXX_FLAGS "-Wl,-z,noexecstack ${CMAKE_CXX_FLAGS}")
+        set(CMAKE_C_FLAGS "-Wl,-z,noexecstack ${CMAKE_C_FLAGS}")
+    endif()
 endif()
 
 # activate static libgcc and libstdc++ linking

--- a/xmrstak/backend/cpu/crypto/cryptonight_common.cpp
+++ b/xmrstak/backend/cpu/crypto/cryptonight_common.cpp
@@ -259,6 +259,12 @@ cryptonight_ctx* cryptonight_alloc_ctx(size_t use_fast_mem, size_t use_mlock, al
 	ptr->long_state = (uint8_t*)mmap(NULL, hashMemSize, PROT_READ | PROT_WRITE,
 		MAP_PRIVATE | MAP_ANON, -1, 0);
 #else
+#ifndef MAP_HUGETLB
+#define MAP_HUGETLB 0
+#endif
+#ifndef MAP_POPULATE
+#define MAP_POPULATE 0
+#endif
 	ptr->long_state = (uint8_t*)mmap(NULL, hashMemSize, PROT_READ | PROT_WRITE,
 		MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB | MAP_POPULATE, -1, 0);
 #endif

--- a/xmrstak/backend/cpu/minethd.cpp
+++ b/xmrstak/backend/cpu/minethd.cpp
@@ -51,6 +51,13 @@
 #include <thread>
 #include <bitset>
 
+#ifdef __CYGWIN__
+#define _WIN32
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+#endif
+
 #ifdef _WIN32
 #include <windows.h>
 #else

--- a/xmrstak/http/httpd.cpp
+++ b/xmrstak/http/httpd.cpp
@@ -23,6 +23,9 @@
 
 #ifndef CONF_NO_HTTPD
 
+#ifdef __CYGWIN__
+#include <strings.h>
+#endif
 
 #include "httpd.hpp"
 #include "webdesign.hpp"

--- a/xmrstak/http/httpd.hpp
+++ b/xmrstak/http/httpd.hpp
@@ -1,6 +1,9 @@
 #pragma once
 
 #include <stdlib.h>
+#ifdef __CYGWIN__
+#include <sys/select.h>
+#endif
 
 struct MHD_Daemon;
 struct MHD_Connection;

--- a/xmrstak/jconf.cpp
+++ b/xmrstak/jconf.cpp
@@ -37,11 +37,16 @@
 #include <numeric>
 #include <algorithm>
 
+#ifdef __CYGWIN__
+#include <strings.h>
+#include <cpuid.h>
+#else
 #ifdef _WIN32
 #define strcasecmp _stricmp
 #include <intrin.h>
 #else
 #include <cpuid.h>
+#endif
 #endif
 
 

--- a/xmrstak/misc/executor.cpp
+++ b/xmrstak/misc/executor.cpp
@@ -46,6 +46,9 @@
 #include <time.h>
 
 
+#ifdef __CYGWIN__
+#include <strings.h>
+#endif //__CYGWIN__
 #ifdef _WIN32
 #define strncasecmp _strnicmp
 #endif // _WIN32
@@ -470,7 +473,7 @@ void executor::on_miner_result(size_t pool_id, job_result& oResult)
 	}
 }
 
-#ifndef _WIN32
+#if !defined(_WIN32) && !defined(__CYGWIN__)
 
 #include <signal.h>
 void disable_sigpipe()


### PR DESCRIPTION
Most features unsupported, use these cmake options: `-DCUDA_ENABLE=OFF -DOpenCL_ENABLE=OFF -DOpenSSL_ENABLE=OFF -DMICROHTTPD_ENABLE=OFF -DHWLOC_ENABLE=OFF`

However it does work, CPU only, no TLS... will work to improve further and get features to work properly.

Seems to magically exit when ASM mode is used, set `cpu.txt` asm:off