### PR TITLE
Add zelerius as a config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Besides [Monero](https://getmonero.org), following coins can be mined using this
 - [QRL](https://theqrl.org)
 - **[Ryo](https://ryo-currency.com) - Upcoming xmr-stak-gui is sponsored by Ryo**
 - [TurtleCoin](https://turtlecoin.lol)
+- [Zelerius](https://zelerius.org)
 
 Ryo currency is a way for us to implement the ideas that we were unable to in
 Monero. See [here](https://github.com/fireice-uk/cryptonote-speedup-demo/) for details.

--- a/xmrstak/jconf.cpp
+++ b/xmrstak/jconf.cpp
@@ -111,7 +111,8 @@ xmrstak::coin_selection coins[] = {
 	{ "qrl",             	 {cryptonight_monero_v8, cryptonight_monero, 255u},   {cryptonight_monero_v8, cryptonight_monero_v8, 0u}, nullptr },
 	{ "ryo",                 {cryptonight_heavy, cryptonight_heavy, 0u},          {cryptonight_heavy, cryptonight_heavy, 0u},   nullptr },
 	{ "stellite",            {cryptonight_monero_v8, cryptonight_stellite, 255u}, {cryptonight_monero_v8, cryptonight_monero_v8, 0u}, nullptr },
-	{ "turtlecoin",          {cryptonight_aeon, cryptonight_aeon, 0u},            {cryptonight_aeon, cryptonight_aeon, 0u},     nullptr }
+    { "turtlecoin",          {cryptonight_aeon, cryptonight_aeon, 0u},            {cryptonight_aeon, cryptonight_aeon, 0u},     nullptr },
+    { "zelerius",            {cryptonight_monero_v8, cryptonight_monero, 0u},     {cryptonight_monero_v8, cryptonight_monero_v8, 0u}, "pool.zelerius.org:3333" }
 };
 
 constexpr size_t coin_algo_size = (sizeof(coins)/sizeof(coins[0]));

--- a/xmrstak/pools.tpl
+++ b/xmrstak/pools.tpl
@@ -33,6 +33,7 @@ POOLCONF],
  *    qrl - Quantum Resistant Ledger
  *    ryo
  *    turtlecoin
+ *    zelerius (automatic switch with block version 6 to cryptonight_v8)
  *
  * Native algorithms which not depends on any block versions:
  *


### PR DESCRIPTION
**XMR-stak feature request for Zelerius Network**

Zelerius Network is switching from CN variant 1 (V7) to CN variant 2 (V8) in order to fight against centralized mining caused by ASIC devices. The issue has been addressed before in the following article written by the Zelerius Network team and published in Medium: https://medium.com/@zelerius/crytonight-variant-2-v8-for-zelerius-network-7ba97489e08e/

The algorithm change is proposed for block 265000, which with an average of 1 block per 30 seconds thrown into the net, it will be accomplished on December 15, 2018. **The hard fork to CN variant 2 (V8) is configured in the Block Major Version 6.**

We request this PR in order to add Zelerius as a config option and automatic switch with block version 6 to CN variant 2 (V8).

**Technical details**

Zelerius Network has algorithm CN variant 1 integrated. It will switch to algorithm CN variant 2 through a Hardfork in the block mentioned previously.

**Blocks version**

```
- Block Major Version 5. Block Minor Version 2 - CN Variant 1
- Block Major Version 6. Block Minor Version 2 - CN Variant 2 - Hard fork
```

We open the PR against **dev** branch as indicated.

Thank you,
Zelerius Developers Team