### PR TITLE
OpenCL: auto tuning option

### DIFF
--- a/doc/tuning.md
+++ b/doc/tuning.md
@@ -148,6 +148,7 @@ description:
 `last delay` should gou slowly to 0.
 If it goes down and than jumps to a very large value multiple times within a minute you should reduce the intensity by 5.
 The `intensity value` will automatically go up and down within the range of +-5% to adjust kernel run-time fluctuations.
+Automatic adjustment is disabled as long as `auto-tuning` is active and will be started after it is finished. 
 If `last delay` goes down to 10ms and the messages stops and repeated from time to time with delays up to 15ms you will have already a good value.
 
 ### disable comp_mode

--- a/xmrstak/backend/amd/amd_gpu/gpu.hpp
+++ b/xmrstak/backend/amd/amd_gpu/gpu.hpp
@@ -35,6 +35,7 @@ struct GpuContext
 	/*Input vars*/
 	size_t deviceIdx;
 	size_t rawIntensity;
+	size_t maxRawIntensity;
 	size_t workSize;
 	int stridedIndex;
 	int memChunk;
@@ -71,5 +72,5 @@ std::vector<GpuContext> getAMDDevices(int index);
 size_t InitOpenCL(GpuContext* ctx, size_t num_gpus, size_t platform_idx);
 size_t XMRSetJob(GpuContext* ctx, uint8_t* input, size_t input_len, uint64_t target, xmrstak_algo miner_algo);
 size_t XMRRunJob(GpuContext* ctx, cl_uint* HashOutput, xmrstak_algo miner_algo);
-uint64_t interleaveAdjustDelay(GpuContext* ctx);
-void updateTimings(GpuContext* ctx, const uint64_t t);
+uint64_t interleaveAdjustDelay(GpuContext* ctx, const bool enableAutoAdjustment = true);
+uint64_t updateTimings(GpuContext* ctx, const uint64_t t);

--- a/xmrstak/backend/amd/config.tpl
+++ b/xmrstak/backend/amd/config.tpl
@@ -43,6 +43,16 @@ GPUCONFIG
 ],
 
 /*
+ * number of rounds per intensity performed to find the best intensity settings
+ *
+ * WARNING: experimental option
+ *
+ * 0 = disable auto tuning
+ * 10 or higher = recommended value if you not already know the best intensity
+ */
+"auto_tune" : 0,
+
+/*
  * Platform index. This will be 0 unless you have different OpenCL platform - eg. AMD and Intel.
  */
 "platform_index" : PLATFORMINDEX,

--- a/xmrstak/backend/amd/jconf.cpp
+++ b/xmrstak/backend/amd/jconf.cpp
@@ -65,6 +65,19 @@ configVal oConfigValues[] = {
 
 constexpr size_t iConfigCnt = (sizeof(oConfigValues)/sizeof(oConfigValues[0]));
 
+
+enum optionalConfigEnum { iAutoTune };
+
+struct optionalConfigVal {
+	optionalConfigEnum iName;
+	const char* sName;
+	Type iType;
+};
+
+optionalConfigVal oOptionalConfigValues[] = {
+	{ iAutoTune, "auto_tune", kNumberType }
+};
+
 inline bool checkType(Type have, Type want)
 {
 	if(want == have)
@@ -196,6 +209,20 @@ bool jconf::GetThreadConfig(size_t id, thd_cfg &cfg)
 size_t jconf::GetPlatformIdx()
 {
 	return prv->configValues[iPlatformIdx]->GetUint64();
+}
+
+size_t jconf::GetAutoTune()
+{
+	const Value* value = GetObjectMember(prv->jsonDoc, oOptionalConfigValues[iAutoTune].sName);
+	if( value != nullptr && value->IsUint64())
+	{
+		return value->GetUint64();
+	}
+	else
+	{
+		printer::inst()->print_msg(L0, "WARNING: OpenCL optional option 'auto-tune' not available");
+	}
+	return 0;
 }
 
 size_t jconf::GetThreadCount()

--- a/xmrstak/backend/amd/jconf.hpp
+++ b/xmrstak/backend/amd/jconf.hpp
@@ -36,6 +36,7 @@ public:
 	size_t GetThreadCount();
 	bool GetThreadConfig(size_t id, thd_cfg &cfg);
 
+	size_t GetAutoTune();
 	size_t GetPlatformIdx();
 
 private:

--- a/xmrstak/backend/amd/minethd.cpp
+++ b/xmrstak/backend/amd/minethd.cpp
@@ -58,6 +58,7 @@ minethd::minethd(miner_work& pWork, size_t iNo, GpuContext* ctx, const jconf::th
 	iTimestamp = 0;
 	pGpuCtx = ctx;
 	this->affinity = cfg.cpu_aff;
+	autoTune = jconf::inst()->GetAutoTune();
 
 	std::unique_lock<std::mutex> lck(thd_aff_set);
 	std::future<void> order_guard = order_fix.get_future();
@@ -187,6 +188,19 @@ void minethd::work_main()
 	uint8_t version = 0;
 	size_t lastPoolId = 0;
 
+	pGpuCtx->maxRawIntensity = pGpuCtx->rawIntensity;
+
+	if(autoTune != 0)
+	{
+		pGpuCtx->rawIntensity = pGpuCtx->computeUnits * pGpuCtx->workSize;
+		pGpuCtx->rawIntensity = std::min(pGpuCtx->maxRawIntensity, pGpuCtx->rawIntensity);
+	}
+	// parameters needed for auto tuning
+	uint32_t cntTestRounds = 0;
+	uint64_t accRuntime = 0;
+	double bestHashrate = 0.0;
+	uint32_t bestIntensity = pGpuCtx->maxRawIntensity;
+
 	while (bQuit == 0)
 	{
 		if (oWork.bStall)
@@ -221,7 +235,6 @@ void minethd::work_main()
 			version = new_version;
 		}
 
-		uint32_t h_per_round = pGpuCtx->rawIntensity;
 		size_t round_ctr = 0;
 
 		assert(sizeof(job_result::sJobID) == sizeof(pool_job::sJobID));
@@ -237,13 +250,15 @@ void minethd::work_main()
 			//Allocate a new nonce every 16 rounds
 			if((round_ctr++ & 0xF) == 0)
 			{
-				globalStates::inst().calc_start_nonce(pGpuCtx->Nonce, oWork.bNiceHash, h_per_round * 16);
+				globalStates::inst().calc_start_nonce(pGpuCtx->Nonce, oWork.bNiceHash, pGpuCtx->rawIntensity * 16);
 				// check if the job is still valid, there is a small possibility that the job is switched
 				if(globalStates::inst().iGlobalJobNo.load(std::memory_order_relaxed) != iJobNo)
 					break;
 			}
 
-			uint64_t t0 = interleaveAdjustDelay(pGpuCtx);
+			// if auto tuning is running we will not adjust the interleave interval
+			const bool adjustInterleave = autoTune == 0;
+			uint64_t t0 = interleaveAdjustDelay(pGpuCtx, adjustInterleave);
 
 			cl_uint results[0x100];
 			memset(results,0,sizeof(cl_uint)*(0x100));
@@ -272,7 +287,56 @@ void minethd::work_main()
 			iHashCount.store(iCount, std::memory_order_relaxed);
 			iTimestamp.store(iStamp, std::memory_order_relaxed);
 
-			updateTimings(pGpuCtx, t0);
+			accRuntime += updateTimings(pGpuCtx, t0);
+
+			// tune intensity
+			if(autoTune != 0)
+			{
+				if(cntTestRounds++ == autoTune)
+				{
+					double avgHashrate = static_cast<double>(cntTestRounds * pGpuCtx->rawIntensity) / (static_cast<double>(accRuntime) / 1000.0);
+					if(avgHashrate > bestHashrate)
+					{
+						bestHashrate = avgHashrate;
+						bestIntensity = pGpuCtx->rawIntensity;
+					}
+
+					// increase always in workSize steps to avoid problems with the compatibility mode
+					pGpuCtx->rawIntensity += pGpuCtx->workSize;
+					// trigger that we query for new nonce's because the number of nonce previous allocated depends on the rawIntensity
+					round_ctr = 0x10;
+
+					if(pGpuCtx->rawIntensity > pGpuCtx->maxRawIntensity)
+					{
+						// lock intensity to the best values
+						autoTune = 0;
+						pGpuCtx->rawIntensity = bestIntensity;
+						printer::inst()->print_msg(L1,"OpenCL %u|%u: lock intensity at %u",
+							pGpuCtx->deviceIdx,
+							pGpuCtx->idWorkerOnDevice,
+							bestIntensity
+						);
+					}
+					else
+					{
+						printer::inst()->print_msg(L1,"OpenCL %u|%u: auto-tune validate intensity %u|%u",
+							pGpuCtx->deviceIdx,
+							pGpuCtx->idWorkerOnDevice,
+							pGpuCtx->rawIntensity,
+							bestIntensity
+						);
+					}
+					// update gpu with new intensity
+					XMRSetJob(pGpuCtx, oWork.bWorkBlob, oWork.iWorkSize, target, miner_algo);
+				}
+				// use 3 rounds to warm up with the new intensity
+				else if(cntTestRounds == autoTune + 3)
+				{
+					// reset values for the next test period
+					cntTestRounds = 0;
+					accRuntime = 0;
+				}
+			}
 
 			std::this_thread::yield();
 		}

--- a/xmrstak/backend/amd/minethd.hpp
+++ b/xmrstak/backend/amd/minethd.hpp
@@ -39,6 +39,7 @@ private:
 
 	std::thread oWorkThd;
 	int64_t affinity;
+	uint32_t autoTune;
 
 	bool bQuit;
 	bool bNoPrefetch;


### PR DESCRIPTION
Add an option to brute force intensity settings and lock in at the intensity with the highest hashrate.

- update documentation of the `interleave` option to mention the side effect with `auto-tune`
- disable `interleave` auto adjustment if `auto-tune` is enabled
- jconf: add `auto-tune` as optional option
