### PR TITLE
Add Support For Pool Supplied Block Versions

### DIFF
--- a/xmrstak/backend/miner_work.hpp
+++ b/xmrstak/backend/miner_work.hpp
@@ -21,12 +21,14 @@ namespace xmrstak
 		bool        bNiceHash;
 		bool        bStall;
 		size_t      iPoolId;
+		uint32_t    bMajorVersion;
+		uint32_t    bMinorVersion;
 
-		miner_work() : iWorkSize(0), bNiceHash(false), bStall(true), iPoolId(invalid_pool_id) { }
+		miner_work() : iWorkSize(0), bNiceHash(false), bStall(true), iPoolId(invalid_pool_id), bMajorVersion(0), bMinorVersion(0) { }
 
 		miner_work(const char* sJobID, const uint8_t* bWork, uint32_t iWorkSize,
-			uint64_t iTarget, bool bNiceHash, size_t iPoolId) : iWorkSize(iWorkSize),
-			iTarget(iTarget), bNiceHash(bNiceHash), bStall(false), iPoolId(iPoolId)
+			uint64_t iTarget, bool bNiceHash, size_t iPoolId, const uint32_t bMajorVersion, const uint32_t bMinorVersion) : iWorkSize(iWorkSize),
+			iTarget(iTarget), bNiceHash(bNiceHash), bStall(false), iPoolId(iPoolId), bMajorVersion(bMajorVersion), bMinorVersion(bMinorVersion)
 		{
 			assert(iWorkSize <= sizeof(bWorkBlob));
 			memcpy(this->sJobID, sJobID, sizeof(miner_work::sJobID));
@@ -44,6 +46,8 @@ namespace xmrstak
 			bNiceHash = from.bNiceHash;
 			bStall = from.bStall;
 			iPoolId = from.iPoolId;
+			bMajorVersion = from.bMajorVersion;
+			bMinorVersion = from.bMinorVersion;
 
 			assert(iWorkSize <= sizeof(bWorkBlob));
 			memcpy(sJobID, from.sJobID, sizeof(sJobID));
@@ -53,7 +57,7 @@ namespace xmrstak
 		}
 
 		miner_work(miner_work&& from) : iWorkSize(from.iWorkSize), iTarget(from.iTarget),
-			bStall(from.bStall), iPoolId(from.iPoolId)
+			bStall(from.bStall), iPoolId(from.iPoolId), bMajorVersion(from.bMajorVersion), bMinorVersion(from.bMinorVersion)
 		{
 			assert(iWorkSize <= sizeof(bWorkBlob));
 			memcpy(sJobID, from.sJobID, sizeof(sJobID));
@@ -69,6 +73,8 @@ namespace xmrstak
 			bNiceHash = from.bNiceHash;
 			bStall = from.bStall;
 			iPoolId = from.iPoolId;
+			bMajorVersion = from.bMajorVersion;
+			bMinorVersion = from.bMinorVersion;
 
 			assert(iWorkSize <= sizeof(bWorkBlob));
 			memcpy(sJobID, from.sJobID, sizeof(sJobID));
@@ -79,6 +85,10 @@ namespace xmrstak
 
 		uint8_t getVersion() const
 		{
+			if (bMajorVersion != 0)
+			{
+				return (uint8_t) bMajorVersion;
+			}
 			return bWorkBlob[0];
 		}
 

--- a/xmrstak/cli/cli-miner.cpp
+++ b/xmrstak/cli/cli-miner.cpp
@@ -865,7 +865,7 @@ int do_benchmark(int block_version, int wait_sec, int work_sec)
 	/* AMD and NVIDIA is currently only supporting work sizes up to 84byte
 	 * \todo fix this issue
 	 */
-	xmrstak::miner_work benchWork = xmrstak::miner_work("", work, 84, 0, false, 0);
+	xmrstak::miner_work benchWork = xmrstak::miner_work("", work, 84, 0, false, 0, 0, 0);
 	printer::inst()->print_msg(L0, "Start a %d second benchmark...",work_sec);
 	xmrstak::globalStates::inst().switch_work(benchWork, dat);
 	uint64_t iStartStamp = get_timestamp_ms();

--- a/xmrstak/misc/executor.cpp
+++ b/xmrstak/misc/executor.cpp
@@ -365,7 +365,7 @@ void executor::on_pool_have_job(size_t pool_id, pool_job& oPoolJob)
 
 	jpsock* pool = pick_pool_by_id(pool_id);
 
-	xmrstak::miner_work oWork(oPoolJob.sJobID, oPoolJob.bWorkBlob, oPoolJob.iWorkLen, oPoolJob.iTarget, pool->is_nicehash(), pool_id);
+	xmrstak::miner_work oWork(oPoolJob.sJobID, oPoolJob.bWorkBlob, oPoolJob.iWorkLen, oPoolJob.iTarget, pool->is_nicehash(), pool_id, oPoolJob.bMajorVersion, oPoolJob.bMinorVersion);
 
 	xmrstak::pool_data dat;
 	dat.iSavedNonce = oPoolJob.iSavedNonce;

--- a/xmrstak/net/jpsock.cpp
+++ b/xmrstak/net/jpsock.cpp
@@ -403,11 +403,13 @@ bool jpsock::process_pool_job(const opq_json_val* params, const uint64_t message
 	if (!params->val->IsObject())
 		return set_socket_error("PARSE error: Job error 1");
 
-	const Value *blob, *jobid, *target, *motd;
+	const Value *blob, *jobid, *target, *motd, *majorVersion, *minorVersion;
 	jobid = GetObjectMember(*params->val, "job_id");
 	blob = GetObjectMember(*params->val, "blob");
 	target = GetObjectMember(*params->val, "target");
 	motd = GetObjectMember(*params->val, "motd");
+	majorVersion = GetObjectMember(*params->val, "blockMajorVersion");
+	minorVersion = GetObjectMember(*params->val, "blockMinorVersion");
 
 	if (jobid == nullptr || blob == nullptr || target == nullptr ||
 		!jobid->IsString() || !blob->IsString() || !target->IsString())
@@ -481,6 +483,16 @@ bool jpsock::process_pool_job(const opq_json_val* params, const uint64_t message
 		return set_socket_error("PARSE error: Job error 5");
 
 	iJobDiff = t64_to_diff(oPoolJob.iTarget);
+
+	if (majorVersion != nullptr && majorVersion->IsUint())
+	{
+		oPoolJob.bMajorVersion = majorVersion->GetUint();
+	}
+
+	if (minorVersion != nullptr && minorVersion->IsUint())
+	{
+		oPoolJob.bMinorVersion = minorVersion->GetUint();
+	}
 
 	std::unique_lock<std::mutex> lck(job_mutex);
 	oCurrentJob = oPoolJob;

--- a/xmrstak/net/msgstruct.hpp
+++ b/xmrstak/net/msgstruct.hpp
@@ -16,10 +16,12 @@ struct pool_job
 	uint64_t	iTarget;
 	uint32_t	iWorkLen;
 	uint32_t	iSavedNonce;
+	uint32_t	bMajorVersion;
+	uint32_t	bMinorVersion;
 
-	pool_job() : iWorkLen(0), iSavedNonce(0) {}
-	pool_job(const char* sJobID, uint64_t iTarget, const uint8_t* bWorkBlob, uint32_t iWorkLen) :
-		iTarget(iTarget), iWorkLen(iWorkLen), iSavedNonce(0)
+	pool_job() : iWorkLen(0), iSavedNonce(0), bMajorVersion(0), bMinorVersion(0) {}
+	pool_job(const char* sJobID, uint64_t iTarget, const uint8_t* bWorkBlob, uint32_t iWorkLen, const uint32_t bMajorVersion, const uint32_t bMinorVersion) :
+		iTarget(iTarget), iWorkLen(iWorkLen), iSavedNonce(0), bMajorVersion(bMajorVersion), bMinorVersion(bMinorVersion)
 	{
 		assert(iWorkLen <= sizeof(pool_job::bWorkBlob));
 		memcpy(this->sJobID, sJobID, sizeof(pool_job::sJobID));


### PR DESCRIPTION
This PR adds support for pool supplied Block versions in the miner job that is provided by the pool.

This alleviates some of the issues experienced with some projects that operate with a parent/root block and the majorVersion of that block is not updated during a fork for various reasons.

See https://github.com/turtlecoin/node-turtle-pool/commit/5671ef9a9c71fda7243815ef1be84087d4da6443 for an example of how the information can be supplied by a pool.