### PR TITLE
Please Add support for ZELERIUS coin

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Besides [Monero](https://getmonero.org), following coins can be mined using this
 - **[Ryo](https://ryo-currency.com) - Upcoming xmr-stak-gui is sponsored by Ryo**
 - [TurtleCoin](https://turtlecoin.lol)
 - [Plenteum](https://www.plenteum.com/)
+- [Zelerius](https://zelerius.org)
 
 Ryo currency is a way for us to implement the ideas that we were unable to in
 Monero. See [here](https://github.com/fireice-uk/cryptonote-speedup-demo/) for details.
@@ -66,6 +67,7 @@ If your prefered coin is not listed, you can choose one of the following algorit
     - cryptonight_v7
     - cryptonight_v7_stellite
     - cryptonight_v8
+    - cryptonight_zelerius
 - 4MiB scratchpad memory
     - cryptonight_haven
     - cryptonight_heavy

--- a/xmrstak/backend/amd/amd_gpu/gpu.cpp
+++ b/xmrstak/backend/amd/amd_gpu/gpu.cpp
@@ -415,7 +415,7 @@ size_t InitOpenCLGpu(cl_context opencl_ctx, GpuContext* ctx, const char* source_
 		 * this is required if the dev pool is mining monero
 		 * but the user tuned there settings for another currency
 		 */
-		if(miner_algo == cryptonight_monero_v8 || miner_algo == cryptonight_turtle)
+		if(miner_algo == cryptonight_monero_v8 || miner_algo == cryptonight_turtle || miner_algo == cryptonight_zelerius)
 		{
 			if(ctx->memChunk < 2)
 				mem_chunk_exp = 1u << 2;

--- a/xmrstak/backend/amd/amd_gpu/opencl/cryptonight.cl
+++ b/xmrstak/backend/amd/amd_gpu/opencl/cryptonight.cl
@@ -30,6 +30,7 @@ R"===(
 #define cryptonight_superfast 12
 #define cryptonight_gpu 13
 #define cryptonight_turtle 14
+#define cryptonight_zelerius 15
 
 /* For Mesa clover support */
 #ifdef cl_clang_storage_class_specifiers
@@ -576,7 +577,7 @@ __kernel void JOIN(cn0,ALGO)(__global ulong *input, __global uint4 *Scratchpad, 
 R"===(
 
 // __NV_CL_C_VERSION checks if NVIDIA opencl is used
-#if((ALGO == cryptonight_monero_v8 || ALGO == cryptonight_turtle) && defined(__NV_CL_C_VERSION))
+#if((ALGO == cryptonight_monero_v8 || ALGO == cryptonight_turtle || ALGO == cryptonight_zelerius) && defined(__NV_CL_C_VERSION))
 #	define SCRATCHPAD_CHUNK(N) (*(__local uint4*)((__local uchar*)(scratchpad_line) + (idxS ^ (N << 4))))
 #	define SCRATCHPAD_CHUNK_GLOBAL (*((__global uint16*)(Scratchpad + (IDX((idx0 & 0x1FFFC0U) >> 4)))))
 #else
@@ -593,7 +594,7 @@ __kernel void JOIN(cn1,ALGO) (__global uint4 *Scratchpad, __global ulong *states
 {
 	ulong a[2];
 
-#if(ALGO == cryptonight_monero_v8 || ALGO == cryptonight_turtle)
+#if(ALGO == cryptonight_monero_v8 || ALGO == cryptonight_turtle || ALGO == cryptonight_zelerius)
 	ulong b[4];
 	uint4 b_x[2];
 // NVIDIA
@@ -607,7 +608,7 @@ __kernel void JOIN(cn1,ALGO) (__global uint4 *Scratchpad, __global ulong *states
 #endif
     __local uint AES0[256], AES1[256];
 
-#if(ALGO == cryptonight_monero_v8 || ALGO == cryptonight_turtle)
+#if(ALGO == cryptonight_monero_v8 || ALGO == cryptonight_turtle || ALGO == cryptonight_zelerius)
 #	if defined(__clang__) && !defined(__NV_CL_C_VERSION)
     __local uint RCP[256];
 #	endif
@@ -623,7 +624,7 @@ __kernel void JOIN(cn1,ALGO) (__global uint4 *Scratchpad, __global ulong *states
         AES0[i] = tmp;
         AES1[i] = rotate(tmp, 8U);
 
-#if((ALGO == cryptonight_monero_v8 || ALGO == cryptonight_turtle) && (defined(__clang__) && !defined(__NV_CL_C_VERSION)))
+#if((ALGO == cryptonight_monero_v8 || ALGO == cryptonight_turtle || ALGO == cryptonight_zelerius) && (defined(__clang__) && !defined(__NV_CL_C_VERSION)))
 		RCP[i] = RCP_C[i];
 #endif
     }
@@ -657,7 +658,7 @@ __kernel void JOIN(cn1,ALGO) (__global uint4 *Scratchpad, __global ulong *states
 
 		b_x[0] = ((uint4 *)b)[0];
 
-#if(ALGO == cryptonight_monero_v8 || ALGO == cryptonight_turtle)
+#if(ALGO == cryptonight_monero_v8 || ALGO == cryptonight_turtle || ALGO == cryptonight_zelerius)
         a[1] = states[1] ^ states[5];
         b[2] = states[8] ^ states[10];
         b[3] = states[9] ^ states[11];
@@ -689,7 +690,7 @@ __kernel void JOIN(cn1,ALGO) (__global uint4 *Scratchpad, __global ulong *states
     {
 			ulong c[2];
 
-#if((ALGO == cryptonight_monero_v8 || ALGO == cryptonight_turtle) && defined(__NV_CL_C_VERSION))
+#if((ALGO == cryptonight_monero_v8 || ALGO == cryptonight_turtle || ALGO == cryptonight_zelerius) && defined(__NV_CL_C_VERSION))
 			uint idxS = idx0 & 0x30U;
  			*scratchpad_line = SCRATCHPAD_CHUNK_GLOBAL;
 #endif
@@ -702,7 +703,7 @@ __kernel void JOIN(cn1,ALGO) (__global uint4 *Scratchpad, __global ulong *states
 			((uint4 *)c)[0] = AES_Round2(AES0, AES1, ((uint4 *)c)[0], ((uint4 *)a)[0]);
 #endif
 
-#if(ALGO == cryptonight_monero_v8 || ALGO == cryptonight_turtle)
+#if(ALGO == cryptonight_monero_v8 || ALGO == cryptonight_turtle || ALGO == cryptonight_zelerius)
         {
 			ulong2 chunk1 = as_ulong2(SCRATCHPAD_CHUNK(1));
 			ulong2 chunk2 = as_ulong2(SCRATCHPAD_CHUNK(2));
@@ -726,7 +727,7 @@ __kernel void JOIN(cn1,ALGO) (__global uint4 *Scratchpad, __global ulong *states
 			SCRATCHPAD_CHUNK(0) = b_x[0];
 			idx0 = as_uint2(c[0]).s0 & MASK;
 
-#elif(ALGO == cryptonight_monero_v8 || ALGO == cryptonight_turtle)
+#elif(ALGO == cryptonight_monero_v8 || ALGO == cryptonight_turtle || ALGO == cryptonight_zelerius)
 			SCRATCHPAD_CHUNK(0) = b_x[0] ^ ((uint4 *)c)[0];
 #	ifdef __NV_CL_C_VERSION
 			// flush shuffled data
@@ -745,7 +746,7 @@ __kernel void JOIN(cn1,ALGO) (__global uint4 *Scratchpad, __global ulong *states
 			uint4 tmp;
 			tmp = SCRATCHPAD_CHUNK(0);
 
-#if(ALGO == cryptonight_monero_v8 || ALGO == cryptonight_turtle)
+#if(ALGO == cryptonight_monero_v8 || ALGO == cryptonight_turtle || ALGO == cryptonight_zelerius)
 			// Use division and square root results from the _previous_ iteration to hide the latency
             tmp.s0 ^= division_result.s0;
             tmp.s1 ^= division_result.s1 ^ sqrt_result;
@@ -801,7 +802,7 @@ __kernel void JOIN(cn1,ALGO) (__global uint4 *Scratchpad, __global ulong *states
 
         ((uint4 *)a)[0] ^= tmp;
 
-#if (ALGO == cryptonight_monero_v8 || ALGO == cryptonight_turtle)
+#if (ALGO == cryptonight_monero_v8 || ALGO == cryptonight_turtle || ALGO == cryptonight_zelerius)
 #	if defined(__NV_CL_C_VERSION)
 			// flush shuffled data
 			SCRATCHPAD_CHUNK_GLOBAL = *scratchpad_line;

--- a/xmrstak/backend/amd/amd_gpu/opencl/fast_int_math_v2.cl
+++ b/xmrstak/backend/amd/amd_gpu/opencl/fast_int_math_v2.cl
@@ -3,7 +3,7 @@ R"===(
  * @author SChernykh
  */
 
-#if(ALGO == cryptonight_monero_v8 || ALGO == cryptonight_turtle)
+#if(ALGO == cryptonight_monero_v8 || ALGO == cryptonight_turtle || ALGO == cryptonight_zelerius)
 
 static const __constant uint RCP_C[256] =
 {

--- a/xmrstak/backend/amd/autoAdjust.hpp
+++ b/xmrstak/backend/amd/autoAdjust.hpp
@@ -132,7 +132,8 @@ private:
 
 			// check if cryptonight_monero_v8 is selected for the user or dev pool
 			bool useCryptonight_v8 = (std::find(neededAlgorithms.begin(), neededAlgorithms.end(), cryptonight_monero_v8) != neededAlgorithms.end() ||
-			                          std::find(neededAlgorithms.begin(), neededAlgorithms.end(), cryptonight_turtle) != neededAlgorithms.end());
+			                          std::find(neededAlgorithms.begin(), neededAlgorithms.end(), cryptonight_turtle) != neededAlgorithms.end() ||
+			                          std::find(neededAlgorithms.begin(), neededAlgorithms.end(), cryptonight_zelerius) != neededAlgorithms.end());
 
 			// true for all cryptonight_heavy derivates since we check the user and dev pool
 			bool useCryptonight_heavy = std::find(neededAlgorithms.begin(), neededAlgorithms.end(), cryptonight_heavy) != neededAlgorithms.end();

--- a/xmrstak/backend/cpu/crypto/cryptonight_aesni.h
+++ b/xmrstak/backend/cpu/crypto/cryptonight_aesni.h
@@ -169,7 +169,7 @@ template<size_t MEM, bool SOFT_AES, bool PREFETCH, xmrstak_algo ALGO>
 void cn_explode_scratchpad(const __m128i* input, __m128i* output)
 {
 	constexpr bool HEAVY_MIX = ALGO == cryptonight_heavy || ALGO == cryptonight_haven || ALGO == cryptonight_bittube2 || ALGO == cryptonight_superfast;
-	
+
 	// This is more than we have registers, compiler will assign 2 keys on the stack
 	__m128i xin0, xin1, xin2, xin3, xin4, xin5, xin6, xin7;
 	__m128i k0, k1, k2, k3, k4, k5, k6, k7, k8, k9;
@@ -288,7 +288,7 @@ void cn_explode_scratchpad_gpu(const uint8_t* input, uint8_t* output)
 		keccakf(hash, 24);
 		memcpy(output, hash, 176);
 		output+=176;
-		
+
 		if(PREFETCH)
 		{
 			_mm_prefetch((const char*)output - 512, _MM_HINT_T2);
@@ -302,7 +302,7 @@ void cn_explode_scratchpad_gpu(const uint8_t* input, uint8_t* output)
 template<size_t MEM, bool SOFT_AES, bool PREFETCH, xmrstak_algo ALGO>
 void cn_implode_scratchpad(const __m128i* input, __m128i* output)
 {
-	constexpr bool HEAVY_MIX = ALGO == cryptonight_heavy || ALGO == cryptonight_haven || 
+	constexpr bool HEAVY_MIX = ALGO == cryptonight_heavy || ALGO == cryptonight_haven ||
 		ALGO == cryptonight_bittube2 || ALGO == cryptonight_superfast || ALGO == cryptonight_gpu;
 
 	// This is more than we have registers, compiler will assign 2 keys on the stack
@@ -584,7 +584,7 @@ inline void set_float_rounding_mode()
 
 #define CN_MONERO_V8_SHUFFLE_0(n, l0, idx0, ax0, bx0, bx1) \
 	/* Shuffle the other 3x16 byte chunks in the current 64-byte cache line */ \
-	if(ALGO == cryptonight_monero_v8 || ALGO == cryptonight_turtle) \
+	if(ALGO == cryptonight_monero_v8 || ALGO == cryptonight_turtle || ALGO == cryptonight_zelerius) \
 	{ \
 		const uint64_t idx1 = idx0 & MASK; \
 		const __m128i chunk1 = _mm_load_si128((__m128i *)&l0[idx1 ^ 0x10]); \
@@ -597,7 +597,7 @@ inline void set_float_rounding_mode()
 
 #define CN_MONERO_V8_SHUFFLE_1(n, l0, idx0, ax0, bx0, bx1, lo, hi) \
 	/* Shuffle the other 3x16 byte chunks in the current 64-byte cache line */ \
-	if(ALGO == cryptonight_monero_v8 || ALGO == cryptonight_turtle) \
+	if(ALGO == cryptonight_monero_v8 || ALGO == cryptonight_turtle || ALGO == cryptonight_zelerius) \
 	{ \
 		const uint64_t idx1 = idx0 & MASK; \
 		const __m128i chunk1 = _mm_xor_si128(_mm_load_si128((__m128i *)&l0[idx1 ^ 0x10]), _mm_set_epi64x(lo, hi)); \
@@ -611,7 +611,7 @@ inline void set_float_rounding_mode()
 	}
 
 #define CN_MONERO_V8_DIV(n, cx, sqrt_result, division_result_xmm, cl) \
-	if(ALGO == cryptonight_monero_v8 || ALGO == cryptonight_turtle) \
+	if(ALGO == cryptonight_monero_v8 || ALGO == cryptonight_turtle || ALGO == cryptonight_zelerius) \
 	{ \
 		uint64_t sqrt_result_tmp; \
 		assign(sqrt_result_tmp, sqrt_result); \
@@ -666,7 +666,7 @@ inline void set_float_rounding_mode()
 		idx0 = h0[0] ^ h0[4]; \
 		ax0 = _mm_set_epi64x(h0[1] ^ h0[5], idx0); \
 		bx0 = _mm_set_epi64x(h0[3] ^ h0[7], h0[2] ^ h0[6]); \
-		if(ALGO == cryptonight_monero_v8 || ALGO == cryptonight_turtle) \
+		if(ALGO == cryptonight_monero_v8 || ALGO == cryptonight_turtle || ALGO == cryptonight_zelerius) \
 		{ \
 			bx1 = _mm_set_epi64x(h0[9] ^ h0[11], h0[8] ^ h0[10]); \
 			division_result_xmm = _mm_cvtsi64_si128(h0[12]); \
@@ -703,7 +703,7 @@ inline void set_float_rounding_mode()
 	ptr0 = (__m128i *)&l0[idx0 & MASK]; \
 	if(PREFETCH) \
 		_mm_prefetch((const char*)ptr0, _MM_HINT_T0); \
-	if(ALGO != cryptonight_monero_v8 && ALGO != cryptonight_turtle) \
+	if(ALGO != cryptonight_monero_v8 && ALGO != cryptonight_turtle && ALGO != cryptonight_zelerius) \
 		bx0 = cx
 
 #define CN_STEP3(n, monero_const, l0, ax0, bx0, idx0, ptr0, lo, cl, ch, al0, ah0, cx, bx1, sqrt_result, division_result_xmm) \
@@ -720,7 +720,7 @@ inline void set_float_rounding_mode()
 		ah0 += lo; \
 		al0 += hi; \
 	} \
-	if(ALGO == cryptonight_monero_v8 || ALGO == cryptonight_turtle) \
+	if(ALGO == cryptonight_monero_v8 || ALGO == cryptonight_turtle || ALGO == cryptonight_zelerius) \
 	{ \
 		bx1 = bx0; \
 		bx0 = cx; \

--- a/xmrstak/backend/cryptonight.hpp
+++ b/xmrstak/backend/cryptonight.hpp
@@ -19,7 +19,8 @@ enum xmrstak_algo
 	cryptonight_monero_v8 = 11,
 	cryptonight_superfast = 12,
 	cryptonight_gpu = 13,
-	cryptonight_turtle = 14
+	cryptonight_turtle = 14,
+	cryptonight_zelerius = 15 // equal to cryptonight_monero_v8 but with less iterations
 };
 
 // define aeon settings
@@ -40,11 +41,15 @@ constexpr uint32_t CRYPTONIGHT_GPU_ITER = 0xC000;
 
 constexpr uint32_t CRYPTONIGHT_MASARI_ITER = 0x40000;
 
-constexpr uint32_t CRYPTONIGHT_SUPERFAST_ITER = 0x20000; 
+constexpr uint32_t CRYPTONIGHT_SUPERFAST_ITER = 0x20000;
 
 constexpr size_t CRYPTONIGHT_TURTLE_MEMORY = 256 * 1024;
 constexpr uint32_t CRYPTONIGHT_TURTLE_MASK = 0x1FFF0;
 constexpr uint32_t CRYPTONIGHT_TURTLE_ITER = 0x10000;
+
+constexpr size_t CRYPTONIGHT_ZELERIUS_MEMORY = 2 * 1024 * 1024;
+constexpr uint32_t CRYPTONIGHT_ZELERIUS_MASK = 0x1FFFF0;
+constexpr uint32_t CRYPTONIGHT_ZELERIUS_ITER = 0x60000;
 
 template<xmrstak_algo ALGO>
 inline constexpr size_t cn_select_memory() { return 0; }
@@ -83,13 +88,16 @@ template<>
 inline constexpr size_t cn_select_memory<cryptonight_bittube2>() { return CRYPTONIGHT_HEAVY_MEMORY; }
 
 template<>
-inline constexpr size_t cn_select_memory<cryptonight_superfast>() { return CRYPTONIGHT_MEMORY; } 
+inline constexpr size_t cn_select_memory<cryptonight_superfast>() { return CRYPTONIGHT_MEMORY; }
 
 template<>
-inline constexpr size_t cn_select_memory<cryptonight_gpu>() { return CRYPTONIGHT_MEMORY; } 
+inline constexpr size_t cn_select_memory<cryptonight_gpu>() { return CRYPTONIGHT_MEMORY; }
 
 template<>
 inline constexpr size_t cn_select_memory<cryptonight_turtle>() { return CRYPTONIGHT_TURTLE_MEMORY; }
+
+template<>
+inline constexpr size_t cn_select_memory<cryptonight_zelerius>() { return CRYPTONIGHT_ZELERIUS_MEMORY; }
 
 inline size_t cn_select_memory(xmrstak_algo algo)
 {
@@ -100,7 +108,7 @@ inline size_t cn_select_memory(xmrstak_algo algo)
 	case cryptonight_monero_v8:
 	case cryptonight_masari:
 	case cryptonight:
-	case cryptonight_superfast: 
+	case cryptonight_superfast:
 	case cryptonight_gpu:
 		return CRYPTONIGHT_MEMORY;
 	case cryptonight_ipbc:
@@ -113,6 +121,8 @@ inline size_t cn_select_memory(xmrstak_algo algo)
 		return CRYPTONIGHT_HEAVY_MEMORY;
 	case cryptonight_turtle:
 		return CRYPTONIGHT_TURTLE_MEMORY;
+	case cryptonight_zelerius:
+		return CRYPTONIGHT_ZELERIUS_MEMORY;
 	default:
 		return 0;
 	}
@@ -155,13 +165,16 @@ template<>
 inline constexpr uint32_t cn_select_mask<cryptonight_bittube2>() { return CRYPTONIGHT_HEAVY_MASK; }
 
 template<>
-inline constexpr uint32_t cn_select_mask<cryptonight_superfast>() { return CRYPTONIGHT_MASK; } 
+inline constexpr uint32_t cn_select_mask<cryptonight_superfast>() { return CRYPTONIGHT_MASK; }
 
 template<>
-inline constexpr uint32_t cn_select_mask<cryptonight_gpu>() { return CRYPTONIGHT_GPU_MASK; } 
+inline constexpr uint32_t cn_select_mask<cryptonight_gpu>() { return CRYPTONIGHT_GPU_MASK; }
 
 template<>
 inline constexpr uint32_t cn_select_mask<cryptonight_turtle>() { return CRYPTONIGHT_TURTLE_MASK; }
+
+template<>
+inline constexpr uint32_t cn_select_mask<cryptonight_zelerius>() { return CRYPTONIGHT_ZELERIUS_MASK; }
 
 inline size_t cn_select_mask(xmrstak_algo algo)
 {
@@ -172,7 +185,7 @@ inline size_t cn_select_mask(xmrstak_algo algo)
 	case cryptonight_monero_v8:
 	case cryptonight_masari:
 	case cryptonight:
-	case cryptonight_superfast: 
+	case cryptonight_superfast:
 		return CRYPTONIGHT_MASK;
 	case cryptonight_ipbc:
 	case cryptonight_aeon:
@@ -186,6 +199,8 @@ inline size_t cn_select_mask(xmrstak_algo algo)
 		return CRYPTONIGHT_GPU_MASK;
 	case cryptonight_turtle:
 		return CRYPTONIGHT_TURTLE_MASK;
+	case cryptonight_zelerius:
+		return CRYPTONIGHT_ZELERIUS_MASK;
 	default:
 		return 0;
 	}
@@ -228,13 +243,16 @@ template<>
 inline constexpr uint32_t cn_select_iter<cryptonight_bittube2>() { return CRYPTONIGHT_HEAVY_ITER; }
 
 template<>
-inline constexpr uint32_t cn_select_iter<cryptonight_superfast>() { return CRYPTONIGHT_SUPERFAST_ITER; } 
+inline constexpr uint32_t cn_select_iter<cryptonight_superfast>() { return CRYPTONIGHT_SUPERFAST_ITER; }
 
 template<>
-inline constexpr uint32_t cn_select_iter<cryptonight_gpu>() { return CRYPTONIGHT_GPU_ITER; } 
+inline constexpr uint32_t cn_select_iter<cryptonight_gpu>() { return CRYPTONIGHT_GPU_ITER; }
 
 template<>
 inline constexpr uint32_t cn_select_iter<cryptonight_turtle>() { return CRYPTONIGHT_TURTLE_ITER; }
+
+template<>
+inline constexpr uint32_t cn_select_iter<cryptonight_zelerius>() { return CRYPTONIGHT_ZELERIUS_ITER; }
 
 inline size_t cn_select_iter(xmrstak_algo algo)
 {
@@ -261,6 +279,8 @@ inline size_t cn_select_iter(xmrstak_algo algo)
 		return CRYPTONIGHT_GPU_ITER;
 	case cryptonight_turtle:
 		return CRYPTONIGHT_TURTLE_ITER;
+	case cryptonight_zelerius:
+		return CRYPTONIGHT_ZELERIUS_ITER;
 	default:
 		return 0;
 	}

--- a/xmrstak/backend/nvidia/nvcc_code/cuda_core.cu
+++ b/xmrstak/backend/nvidia/nvcc_code/cuda_core.cu
@@ -311,7 +311,7 @@ __global__ void cryptonight_core_gpu_phase2_double( int threads, int bfactor, in
 	uint64_t bx1;
 	uint32_t sqrt_result;
 	uint64_t division_result;
-	if(ALGO == cryptonight_monero_v8 || ALGO == cryptonight_turtle)
+	if(ALGO == cryptonight_monero_v8 || ALGO == cryptonight_turtle || ALGO == cryptonight_zelerius)
 	{
 		bx0 = ((uint64_t*)(d_ctx_b + thread * 12))[sub];
 		bx1 = ((uint64_t*)(d_ctx_b + thread * 12 + 4))[sub];
@@ -351,7 +351,7 @@ __global__ void cryptonight_core_gpu_phase2_double( int threads, int bfactor, in
 			t_fn0( cx.y & 0xff ) ^ t_fn1( (cx2.x >> 8) & 0xff ) ^ rotate16(t_fn0( (cx2.y >> 16) & 0xff ) ^ t_fn1( (cx.x >> 24 ) ))
 		);
 
-		if(ALGO == cryptonight_monero_v8 || ALGO == cryptonight_turtle)
+		if(ALGO == cryptonight_monero_v8 || ALGO == cryptonight_turtle || ALGO == cryptonight_zelerius)
 		{
 
 			const uint64_t chunk1 = myChunks[ idx1 ^ 2 + sub ];
@@ -394,14 +394,14 @@ __global__ void cryptonight_core_gpu_phase2_double( int threads, int bfactor, in
 		else
 			((ulonglong4*)myChunks)[sub] = ((ulonglong4*)ptr0)[sub];
 
-		if(ALGO != cryptonight_monero_v8 && ALGO != cryptonight_turtle)
+		if(ALGO != cryptonight_monero_v8 && ALGO != cryptonight_turtle && ALGO != cryptonight_zelerius)
 			bx0 = cx_aes;
 
 		uint64_t cx_mul;
 		((uint32_t*)&cx_mul)[0] = shuffle<2>(sPtr, sub, cx_aes.x , 0);
 		((uint32_t*)&cx_mul)[1] = shuffle<2>(sPtr, sub, cx_aes.y , 0);
 
-		if((ALGO == cryptonight_monero_v8 || ALGO == cryptonight_turtle) && sub == 1)
+		if((ALGO == cryptonight_monero_v8 || ALGO == cryptonight_turtle || ALGO == cryptonight_zelerius) && sub == 1)
 		{
 			// Use division and square root results from the _previous_ iteration to hide the latency
 			((uint32_t*)&division_result)[1] ^= sqrt_result;
@@ -425,7 +425,7 @@ __global__ void cryptonight_core_gpu_phase2_double( int threads, int bfactor, in
 			uint64_t cl = ((uint64_t*)myChunks)[ idx1 ];
 			// sub 0 -> hi, sub 1 -> lo
 			uint64_t res = sub == 0 ? __umul64hi( cx_mul, cl ) : cx_mul * cl;
-			if(ALGO == cryptonight_monero_v8 || ALGO == cryptonight_turtle)
+			if(ALGO == cryptonight_monero_v8 || ALGO == cryptonight_turtle || ALGO == cryptonight_zelerius)
 			{
 				const uint64_t chunk1 = myChunks[ idx1 ^ 2 + sub ] ^ res;
 				uint64_t chunk2 = myChunks[ idx1 ^ 4 + sub ];
@@ -442,7 +442,7 @@ __global__ void cryptonight_core_gpu_phase2_double( int threads, int bfactor, in
 			}
 			ax0 += res;
 		}
-		if(ALGO == cryptonight_monero_v8 || ALGO == cryptonight_turtle)
+		if(ALGO == cryptonight_monero_v8 || ALGO == cryptonight_turtle || ALGO == cryptonight_zelerius)
 		{
 			bx1 = bx0;
 			bx0 = cx_aes;
@@ -465,7 +465,7 @@ __global__ void cryptonight_core_gpu_phase2_double( int threads, int bfactor, in
 	if ( bfactor > 0 )
 	{
 		((uint64_t*)(d_ctx_a + thread * 4))[sub] = ax0;
-		if(ALGO == cryptonight_monero_v8 || ALGO == cryptonight_turtle)
+		if(ALGO == cryptonight_monero_v8 || ALGO == cryptonight_turtle || ALGO == cryptonight_zelerius)
 		{
 			((uint64_t*)(d_ctx_b + thread * 12))[sub] = bx0;
 			((uint64_t*)(d_ctx_b + thread * 12 + 4))[sub] = bx1;
@@ -773,7 +773,7 @@ void cryptonight_core_gpu_hash(nvid_ctx* ctx, uint32_t nonce)
 
 	for ( int i = 0; i < partcount; i++ )
 	{
-		if(ALGO == cryptonight_monero_v8 || ALGO == cryptonight_turtle)
+		if(ALGO == cryptonight_monero_v8 || ALGO == cryptonight_turtle || ALGO == cryptonight_zelerius)
 		{
 			// two threads per block
 			CUDA_CHECK_MSG_KERNEL(
@@ -959,7 +959,10 @@ void cryptonight_core_cpu_hash(nvid_ctx* ctx, xmrstak_algo miner_algo, uint32_t 
 		cryptonight_core_gpu_hash_gpu<CRYPTONIGHT_GPU_ITER, CRYPTONIGHT_GPU_MASK, CRYPTONIGHT_MEMORY, cryptonight_gpu, 1>,
 
 		cryptonight_core_gpu_hash<CRYPTONIGHT_TURTLE_ITER, CRYPTONIGHT_TURTLE_MASK, CRYPTONIGHT_TURTLE_MEMORY/4, cryptonight_turtle, 0>,
-		cryptonight_core_gpu_hash<CRYPTONIGHT_TURTLE_ITER, CRYPTONIGHT_TURTLE_MASK, CRYPTONIGHT_TURTLE_MEMORY/4, cryptonight_turtle, 1>
+		cryptonight_core_gpu_hash<CRYPTONIGHT_TURTLE_ITER, CRYPTONIGHT_TURTLE_MASK, CRYPTONIGHT_TURTLE_MEMORY/4, cryptonight_turtle, 1>,
+
+		cryptonight_core_gpu_hash<CRYPTONIGHT_ZELERIUS_ITER, CRYPTONIGHT_ZELERIUS_MASK, CRYPTONIGHT_ZELERIUS_MEMORY/4, cryptonight_zelerius, 0>,
+		cryptonight_core_gpu_hash<CRYPTONIGHT_ZELERIUS_ITER, CRYPTONIGHT_ZELERIUS_MASK, CRYPTONIGHT_ZELERIUS_MEMORY/4, cryptonight_zelerius, 1>
 	};
 
 	std::bitset<1> digit;

--- a/xmrstak/backend/nvidia/nvcc_code/cuda_extra.cu
+++ b/xmrstak/backend/nvidia/nvcc_code/cuda_extra.cu
@@ -127,7 +127,7 @@ __global__ void cryptonight_extra_gpu_prepare( int threads, uint32_t * __restric
 	XOR_BLOCKS_DST( ctx_state, ctx_state + 8, ctx_a );
 	XOR_BLOCKS_DST( ctx_state + 4, ctx_state + 12, ctx_b );
 	memcpy( d_ctx_a + thread * 4, ctx_a, 4 * 4 );
-	if(ALGO == cryptonight_monero_v8 || ALGO == cryptonight_turtle)
+	if(ALGO == cryptonight_monero_v8 || ALGO == cryptonight_turtle || ALGO == cryptonight_zelerius)
 	{
 		memcpy( d_ctx_b + thread * 12, ctx_b, 4 * 4 );
 		// bx1
@@ -310,8 +310,11 @@ extern "C" int cryptonight_extra_cpu_init(nvid_ctx* ctx)
 		// create a double buffer for the state to exchange the mixed state to phase1
 		CUDA_CHECK(ctx->device_id, cudaMalloc(&ctx->d_ctx_state2, 50 * sizeof(uint32_t) * wsize));
 	}
-	else if(std::find(neededAlgorithms.begin(), neededAlgorithms.end(), cryptonight_monero_v8) != neededAlgorithms.end() ||
-	        std::find(neededAlgorithms.begin(), neededAlgorithms.end(), cryptonight_turtle) != neededAlgorithms.end() )
+	else if(
+		std::find(neededAlgorithms.begin(), neededAlgorithms.end(), cryptonight_monero_v8) != neededAlgorithms.end() ||
+		std::find(neededAlgorithms.begin(), neededAlgorithms.end(), cryptonight_turtle) != neededAlgorithms.end() ||
+		std::find(neededAlgorithms.begin(), neededAlgorithms.end(), cryptonight_zelerius) != neededAlgorithms.end()
+	)
 	{
 		// bx1 (16byte), division_result (8byte) and sqrt_result (8byte)
 		ctx_b_size = 3 * 4 * sizeof(uint32_t) * wsize;
@@ -377,6 +380,11 @@ extern "C" void cryptonight_extra_cpu_prepare(nvid_ctx* ctx, uint32_t startNonce
 	{
 		CUDA_CHECK_KERNEL(ctx->device_id, cryptonight_extra_gpu_prepare<cryptonight_gpu><<<grid, block >>>( wsize, ctx->d_input, ctx->inputlen, startNonce,
 			ctx->d_ctx_state,ctx->d_ctx_state2, ctx->d_ctx_a, ctx->d_ctx_b, ctx->d_ctx_key1, ctx->d_ctx_key2 ));
+	}
+	else if (miner_algo == cryptonight_zelerius)
+	{
+		CUDA_CHECK_KERNEL(ctx->device_id, cryptonight_extra_gpu_prepare<cryptonight_zelerius> << <grid, block >> > (wsize, ctx->d_input, ctx->inputlen, startNonce,
+			ctx->d_ctx_state, ctx->d_ctx_state2, ctx->d_ctx_a, ctx->d_ctx_b, ctx->d_ctx_key1, ctx->d_ctx_key2));
 	}
 	else
 	{
@@ -746,7 +754,8 @@ extern "C" int cuda_get_deviceinfo(nvid_ctx* ctx)
 
 		// check if cryptonight_monero_v8 is selected for the user pool
 		bool useCryptonight_v8 = (std::find(neededAlgorithms.begin(), neededAlgorithms.end(), cryptonight_monero_v8) != neededAlgorithms.end() ||
-		                          std::find(neededAlgorithms.begin(), neededAlgorithms.end(), cryptonight_turtle) != neededAlgorithms.end());
+		                          std::find(neededAlgorithms.begin(), neededAlgorithms.end(), cryptonight_turtle) != neededAlgorithms.end() ||
+		                          std::find(neededAlgorithms.begin(), neededAlgorithms.end(), cryptonight_zelerius) != neededAlgorithms.end());
 
 		// overwrite default config if cryptonight_monero_v8 is mined and GPU has at least compute capability 5.0
 		if(useCryptonight_v8 && gpuArch >= 50)
@@ -770,7 +779,7 @@ extern "C" int cuda_get_deviceinfo(nvid_ctx* ctx)
 			size_t blockOptimal = 8 * ctx->device_mpcount;
 			if(gpuArch >= 70)
 				blockOptimal = 5 *  ctx->device_mpcount;
-			
+
 			if(blockOptimal * threads * hashMemSize < limitedMemory)
 			{
 				ctx->device_threads = threads;

--- a/xmrstak/jconf.cpp
+++ b/xmrstak/jconf.cpp
@@ -100,6 +100,7 @@ xmrstak::coin_selection coins[] = {
 	{ "cryptonight_lite_v7_xor", {cryptonight_aeon, cryptonight_ipbc, 255u},      {cryptonight_aeon, cryptonight_aeon, 0u}, nullptr },
 	{ "cryptonight_superfast",   {cryptonight_heavy, cryptonight_superfast, 255u},{cryptonight_heavy, cryptonight_superfast, 0u},   nullptr },
 	{ "cryptonight_turtle",  {cryptonight_turtle, cryptonight_turtle, 0u},      {cryptonight_turtle, cryptonight_turtle, 0u},   nullptr },
+	{ "cryptonight_zelerius", {cryptonight_zelerius, cryptonight_zelerius, 0u},   {cryptonight_zelerius, cryptonight_zelerius, 0u}, nullptr },
 	{ "cryptonight_v7",      {cryptonight_monero_v8, cryptonight_monero, 255u},   {cryptonight_monero_v8, cryptonight_monero_v8, 0u}, nullptr },
 	{ "cryptonight_v8",      {cryptonight_monero_v8, cryptonight_monero_v8, 255u},   {cryptonight_monero_v8, cryptonight_monero_v8, 0u}, nullptr },
 	{ "cryptonight_v7_stellite", {cryptonight_monero_v8, cryptonight_stellite, 255u}, {cryptonight_monero_v8, cryptonight_monero_v8, 0u}, nullptr },
@@ -114,7 +115,8 @@ xmrstak::coin_selection coins[] = {
 	{ "ryo",                 {cryptonight_gpu, cryptonight_heavy, 6u},            {cryptonight_gpu, cryptonight_heavy, 6u},   nullptr },
 	{ "stellite",            {cryptonight_monero_v8, cryptonight_stellite, 255u}, {cryptonight_monero_v8, cryptonight_monero_v8, 0u}, nullptr },
 	{ "turtlecoin",          {cryptonight_turtle, cryptonight_aeon, 5u},            {cryptonight_aeon, cryptonight_aeon, 0u},     nullptr },
-	{ "plenteum",			 {cryptonight_turtle, cryptonight_aeon, 5u},            {cryptonight_aeon, cryptonight_aeon, 0u},     nullptr }
+	{ "plenteum",			 {cryptonight_turtle, cryptonight_aeon, 5u},            {cryptonight_aeon, cryptonight_aeon, 0u},     nullptr },
+	{ "zelerius",            {cryptonight_zelerius, cryptonight_monero_v8, 7u},   {cryptonight_zelerius, cryptonight_zelerius, 0u}, "pool.zelerius.org:3333" }
 };
 
 constexpr size_t coin_algo_size = (sizeof(coins)/sizeof(coins[0]));

--- a/xmrstak/misc/executor.cpp
+++ b/xmrstak/misc/executor.cpp
@@ -566,6 +566,7 @@ void executor::ex_main()
 		else
 			pools.emplace_front(0, "donate.xmr-stak.net:5511", "", "", "", 0.0, true, false, "", false);
 		break;
+	case cryptonight_zelerius:
 	case cryptonight_monero_v8:
 	case cryptonight_monero:
 	case cryptonight_turtle:

--- a/xmrstak/net/jpsock.cpp
+++ b/xmrstak/net/jpsock.cpp
@@ -712,6 +712,9 @@ bool jpsock::cmd_submit(const char* sJobId, uint32_t iNonce, const uint8_t* bRes
 		case cryptonight_turtle:
 			algo_name = "cryptonight_turtle";
 			break;
+		case cryptonight_zelerius:
+			algo_name = "cryptonight_zelerius";
+			break;
 		default:
 			algo_name = "unknown";
 			break;

--- a/xmrstak/pools.tpl
+++ b/xmrstak/pools.tpl
@@ -34,6 +34,7 @@ POOLCONF],
  *    ryo
  *    turtlecoin
  *    plenteum
+ *    zelerius
  *
  * Native algorithms which not depends on any block versions:
  *
@@ -48,6 +49,7 @@ POOLCONF],
  *    cryptonight_superfast
  *    cryptonight_v7
  *    cryptonight_v8
+ *    cryptonight_zelerius
  *    # 4MiB scratchpad memory
  *    cryptonight_bittube2
  *    cryptonight_haven


### PR DESCRIPTION
**From #2191** 
_Fixed indentation and started from current work_
_Please check the network hashrate https://explorer.zelerius.org and https://miningpoolstats.stream/zelerius_

 **Please sdd Zelerius as an algorithm**

Added as: **cryptonight_zelerius** and **zelerius** options.
Zelerius Network is switching from CN variant 2 (Monero V8) to CN variant Zelerius ( this is cryptonight_monero_v8 but with less iterations -> 393216 )

The algorithm change will be configured in the Block Major Version 7.

We request this PR in order to add Zelerius as an algortihm option (cryptonight_zelerius) and automatic switch (zelerius) with block version 7.

**Test Network**

We are testing in https://xyztest.zelerius.org
The zelerius code is here https://github.com/zelerius/Zelerius-Network/tree/development (development branch)

**Block version**

```
- Block Major Version 6: CN Variant Monero V8 - cryptonight_v8
- Block Major Version 7: CN Variant Zelerius - cryptonight_zelerius
```

We open the PR against **dev** branch as indicated.
Please tell us about any problem you find in the code. We have test it and it works perfectly.

Thank you,
Zelerius Developers Team
email -> team@zelerius.org
My Telegram -> https://telegram.me/viczzz
Discord user: **Vic#5455** and Zelerius group -> https://discord.gg/fv3jg7d