### PR TITLE
CUDA. fix static in global kernel

### DIFF
--- a/xmrstak/backend/nvidia/nvcc_code/cuda_cryptonight_gpu.hpp
+++ b/xmrstak/backend/nvidia/nvcc_code/cuda_cryptonight_gpu.hpp
@@ -415,7 +415,7 @@ __forceinline__ __device__ void sync()
 template<size_t ITERATIONS, uint32_t MEMORY>
 __global__ void cryptonight_core_gpu_phase2_gpu(int32_t *spad, int *lpad_in, int bfactor, int partidx, uint32_t * roundVs, uint32_t * roundS)
 {
-	static constexpr uint32_t MASK = ((MEMORY-1) >> 6) << 6;
+	constexpr uint32_t MASK = ((MEMORY-1) >> 6) << 6;
 
 	const int batchsize = (ITERATIONS * 2) >> ( 1 + bfactor );
 


### PR DESCRIPTION
Remove `static constexpr` within the global kernel. This is not
supported by all CUDA versions.
