### PR TITLE
OpenCL: fix groestl

### DIFF
--- a/xmrstak/backend/amd/amd_gpu/opencl/cryptonight.cl
+++ b/xmrstak/backend/amd/amd_gpu/opencl/cryptonight.cl
@@ -1248,7 +1248,6 @@ __kernel void Groestl(__global ulong *states, __global uint *BranchBuf, __global
 
         State[7] = 0x0001000000000000UL;
 
-        #pragma unroll 4
         for(uint i = 0; i < 4; ++i)
         {
             volatile ulong H[8], M[8];


### PR DESCRIPTION
@xmrig provided the information that the driver 19.2.1 for vega also
create invalid results if pragma unroll is used for the groestl algo.