### PR TITLE
OpenCL: fix groestl again

### DIFF
--- a/xmrstak/backend/amd/amd_gpu/opencl/cryptonight.cl
+++ b/xmrstak/backend/amd/amd_gpu/opencl/cryptonight.cl
@@ -1248,6 +1248,7 @@ __kernel void Groestl(__global ulong *states, __global uint *BranchBuf, __global
 
         State[7] = 0x0001000000000000UL;
 
+		#pragma unroll 3
         for(uint i = 0; i < 4; ++i)
         {
             volatile ulong H[8], M[8];


### PR DESCRIPTION
With #2212 I fixed groestl for the windows driver 19.2.1 and VEGA gpus.
This fix break the rocm support.
Therefore I will switch to `unroll 3` to avoid hopfully both bugs.
@xmrig mentioned in a private chat the `unroll 3` is also solving the
windows issue.
