### PR TITLE
CUDA/OpenCL: use shared mem object

### DIFF
--- a/xmrstak/backend/nvidia/nvcc_code/cuda_core.cu
+++ b/xmrstak/backend/nvidia/nvcc_code/cuda_core.cu
@@ -895,7 +895,7 @@ void cryptonight_core_gpu_hash_gpu(nvid_ctx* ctx, uint32_t nonce, const xmrstak_
 			ctx->device_id,
 			// 36 x 16byte x numThreads
 			xmrstak::nvidia::cryptonight_core_gpu_phase2_gpu
-				<<<ctx->device_blocks, ctx->device_threads * 16,  36 * 16 * ctx->device_threads>>>
+				<<<ctx->device_blocks, ctx->device_threads * 16,  32 * 16 * ctx->device_threads>>>
 				(
 					ITERATIONS,
 					MEM,

--- a/xmrstak/backend/nvidia/nvcc_code/cuda_cryptonight_gpu.hpp
+++ b/xmrstak/backend/nvidia/nvcc_code/cuda_cryptonight_gpu.hpp
@@ -411,6 +411,12 @@ __forceinline__ __device__ void sync()
 #endif
 }
 
+struct SharedMemChunk
+{
+	__m128i out[16];
+	__m128 va[16];
+};
+
 __global__ void cryptonight_core_gpu_phase2_gpu(
 	const uint32_t ITERATIONS,  const size_t MEMORY, const uint32_t MASK,
 	int32_t *spad, int *lpad_in, int bfactor, int partidx, uint32_t * roundVs, uint32_t * roundS)
@@ -418,20 +424,14 @@ __global__ void cryptonight_core_gpu_phase2_gpu(
 
 	const int batchsize = (ITERATIONS * 2) >> ( 1 + bfactor );
 
-	extern __shared__ __m128i smemExtern_in[];
+	extern __shared__ SharedMemChunk smemExtern_in[];
 
 	const uint32_t chunk = threadIdx.x / 16;
 	const uint32_t numHashPerBlock = blockDim.x / 16;
 
 	int* lpad = (int*)((uint8_t*)lpad_in + size_t(MEMORY) * (blockIdx.x * numHashPerBlock + chunk));
 
-	__m128i* smem = smemExtern_in + 4 * chunk;
-
-	__m128i* smemExtern = smemExtern_in + numHashPerBlock * 4;
-	__m128i* smemOut = smemExtern + 16 * chunk;
-
-	smemExtern = smemExtern + numHashPerBlock * 16;
-	__m128* smemVa = (__m128*)smemExtern + 16 * chunk;
+	SharedMemChunk* smem = smemExtern_in + chunk;
 
 	uint32_t tid = threadIdx.x % 16;
 
@@ -458,43 +458,44 @@ __global__ void cryptonight_core_gpu_phase2_gpu(
 	for(size_t i = 0; i < batchsize; i++)
 	{
 		sync();
-		((int*)smem)[tid] = ((int*)scratchpad_ptr(s, tidd, lpad, MASK))[tidm];
+		int tmp = ((int*)scratchpad_ptr(s, tidd, lpad, MASK))[tidm];
+		((int*)smem->out)[tid] = tmp;
 		sync();
 
 		__m128 rc = vs;
 		single_comupte_wrap(
 			tidm,
-			*(smem + look[tid][0]),
-			*(smem + look[tid][1]),
-			*(smem + look[tid][2]),
-			*(smem + look[tid][3]),
-			ccnt[tid], rc, smemVa[tid],
-			smemOut[tid]
+			*(smem->out + look[tid][0]),
+			*(smem->out + look[tid][1]),
+			*(smem->out + look[tid][2]),
+			*(smem->out + look[tid][3]),
+			ccnt[tid], rc, smem->va[tid],
+			smem->out[tid]
 		);
 
 		sync();
 
-		int outXor = ((int*)smemOut)[block];
+		int outXor = ((int*)smem->out)[block];
 		for(uint32_t dd = block + 4; dd < (tidd + 1) * 16; dd += 4)
-			outXor ^= ((int*)smemOut)[dd];
+			outXor ^= ((int*)smem->out)[dd];
 
-		((int*)scratchpad_ptr(s, tidd, lpad, MASK))[tidm] = outXor ^ ((int*)smem)[tid];
-		((int*)smemOut)[tid] = outXor;
+		((int*)scratchpad_ptr(s, tidd, lpad, MASK))[tidm] = outXor ^ tmp;
+		((int*)smem->out)[tid] = outXor;
 
-		float va_tmp1 = ((float*)smemVa)[block] + ((float*)smemVa)[block + 4];
-		float va_tmp2 = ((float*)smemVa)[block+ 8] + ((float*)smemVa)[block + 12];
-		((float*)smemVa)[tid] = va_tmp1 + va_tmp2;
-
-		sync();
-
-		__m128i out2 = smemOut[0] ^ smemOut[1] ^ smemOut[2] ^ smemOut[3];
-		va_tmp1 = ((float*)smemVa)[block] + ((float*)smemVa)[block + 4];
-		va_tmp2 = ((float*)smemVa)[block + 8] + ((float*)smemVa)[block + 12];
-		((float*)smemVa)[tid] = va_tmp1 + va_tmp2;
+		float va_tmp1 = ((float*)smem->va)[block] + ((float*)smem->va)[block + 4];
+		float va_tmp2 = ((float*)smem->va)[block+ 8] + ((float*)smem->va)[block + 12];
+		((float*)smem->va)[tid] = va_tmp1 + va_tmp2;
 
 		sync();
 
-		vs = smemVa[0];
+		__m128i out2 = smem->out[0] ^ smem->out[1] ^ smem->out[2] ^ smem->out[3];
+		va_tmp1 = ((float*)smem->va)[block] + ((float*)smem->va)[block + 4];
+		va_tmp2 = ((float*)smem->va)[block + 8] + ((float*)smem->va)[block + 12];
+		((float*)smem->va)[tid] = va_tmp1 + va_tmp2;
+
+		sync();
+
+		vs = smem->va[0];
 		vs.abs(); // take abs(va) by masking the float sign bit
 		auto xx = _mm_mul_ps(vs, __m128(16777216.0f));
 		// vs range 0 - 64


### PR DESCRIPTION
This PR includes #2222

Combine the shared memory for a hash within one struct.
Reduce the shared memory footprint per hash by 64 byte.