### PR TITLE
CMakeLists.txt: Adjust OpenCL probing to find OCL SDK Light

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,13 @@ endif(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 
 # help to find cuda on systems with a software module system
 list(APPEND CMAKE_PREFIX_PATH "$ENV{CUDA_ROOT}")
+
+# help to find AMD OCL SDK Light (replaced APP SDK)
+list(APPEND CMAKE_PREFIX_PATH "$ENV{OCL_ROOT}")
+
+# help to find AMD app SDK on systems with a software module system
+list(APPEND CMAKE_PREFIX_PATH "$ENV{AMDAPPSDKROOT}")
+
 # allow user to extent CMAKE_PREFIX_PATH via environment variable
 list(APPEND CMAKE_PREFIX_PATH "$ENV{CMAKE_PREFIX_PATH}")
 
@@ -213,11 +220,6 @@ else()
     add_definitions("-DCONF_NO_CUDA")
 endif()
 
-# help to find AMD app SDK on systems with a software module system
-list(APPEND CMAKE_PREFIX_PATH "$ENV{AMDAPPSDKROOT}")
-# allow user to extent CMAKE_PREFIX_PATH via environment variable
-list(APPEND CMAKE_PREFIX_PATH "$ENV{CMAKE_PREFIX_PATH}")
-
 ###############################################################################
 # Find OpenCL
 ###############################################################################
@@ -231,6 +233,7 @@ if(OpenCL_ENABLE)
             OpenCL/cl.h
         NO_DEFAULT_PATH
         PATHS
+            ENV "OCL_ROOT"
             ENV "OpenCL_ROOT"
             ENV AMDAPPSDKROOT
             ENV ATISTREAMSDKROOT
@@ -247,6 +250,7 @@ if(OpenCL_ENABLE)
             OpenCL.lib
         NO_DEFAULT_PATH
         PATHS
+            ENV "OCL_ROOT"
             ENV "OpenCL_ROOT"
             ENV AMDAPPSDKROOT
             ENV ATISTREAMSDKROOT


### PR DESCRIPTION
Add `OCL_ROOT` envvar support for Windows OCL SDK Light autodetection and prefer it over AMD APP SDK if both are installed.  Tested on Win7 with both SDKs installed (and all CUDAs and Intel OpenCL SDK also... haha) it still selected properly.

`OCL_ROOT` envvar can be preloaded with alternate OpenCL and I have also tested using it to point to nVidia OpenCL and etc, CMake finds all and result builds fine.  Older versions you would have used `AMDAPPSDKROOT` envvar to do the same thing, but when `OCL_ROOT` exists it will take precedence over all.

Moved `CMAKE_PREFIX_PATH` handling all to the top, previously the `$ENV{CMAKE_PREFIX_PATH}` would be added to the list twice (once at top and once after AMD path).

Fixes #2235 proper user expectation that it should detect automatically and build without calculating and passing exact locations.