### PR TITLE
[WIP] Increase max job input length (needed by Masari)

### DIFF
--- a/xmrstak/backend/amd/amd_gpu/gpu.hpp
+++ b/xmrstak/backend/amd/amd_gpu/gpu.hpp
@@ -71,6 +71,8 @@ uint32_t getNumPlatforms();
 int getAMDPlatformIdx();
 std::vector<GpuContext> getAMDDevices(int index);
 
+constexpr size_t amd_max_input_len = 108;
+
 size_t InitOpenCL(GpuContext* ctx, size_t num_gpus, size_t platform_idx);
 size_t XMRSetJob(GpuContext* ctx, uint8_t* input, size_t input_len, uint64_t target, const xmrstak_algo& miner_algo);
 size_t XMRRunJob(GpuContext* ctx, cl_uint* HashOutput, const xmrstak_algo& miner_algo);


### PR DESCRIPTION
The current 84 maximum job length for jobs on AMD isn't sufficient for Masari, which now needs 108.  This increases it and also adds an error message to catch this if it happens again.

Fixes #2233 