### PR TITLE
CN_GPU: Fix old compilers and old kernels (Clang 3.5 tested, without CONFIG_HUGETLBFS)

### DIFF
--- a/xmrstak/backend/cpu/crypto/cn_gpu_avx.cpp
+++ b/xmrstak/backend/cpu/crypto/cn_gpu_avx.cpp
@@ -2,6 +2,12 @@
 #include "../../cryptonight.hpp"
 
 #pragma GCC target ("avx2")
+#ifndef _mm256_bslli_epi128
+	#define _mm256_bslli_epi128(a, count) _mm256_slli_si256((a), (count))
+#endif
+#ifndef _mm256_bsrli_epi128
+	#define _mm256_bsrli_epi128(a, count) _mm256_srli_si256((a), (count))
+#endif
 
 inline void prep_dv_avx(__m256i* idx, __m256i& v, __m256& n01)
 {

--- a/xmrstak/backend/cpu/crypto/cryptonight_common.cpp
+++ b/xmrstak/backend/cpu/crypto/cryptonight_common.cpp
@@ -261,6 +261,13 @@ cryptonight_ctx* cryptonight_alloc_ctx(size_t use_fast_mem, size_t use_mlock, al
 #else
 	ptr->long_state = (uint8_t*)mmap(NULL, hashMemSize, PROT_READ | PROT_WRITE,
 		MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB | MAP_POPULATE, -1, 0);
+	if (ptr->long_state == MAP_FAILED)
+	{
+		// try without MAP_HUGETLB for crappy kernels
+		msg->warning = "mmap with HUGETLB failed, attempting without it (you should fix your kernel)";
+		ptr->long_state = (uint8_t*)mmap(NULL, hashMemSize, PROT_READ | PROT_WRITE,
+			MAP_PRIVATE | MAP_ANONYMOUS | MAP_POPULATE, -1, 0);
+	}
 #endif
 
 	if (ptr->long_state == MAP_FAILED)


### PR DESCRIPTION
This makes CN_GPU compile on Clang 3.5, and then furthermore allow allocations without HUGETLB (with warning) since it is faster than always-slow mode even though not ideal.