### PR TITLE
CPU: fix cryptonight_r slowdown

### DIFF
--- a/xmrstak/backend/cpu/crypto/cryptonight_aesni.h
+++ b/xmrstak/backend/cpu/crypto/cryptonight_aesni.h
@@ -1326,7 +1326,10 @@ struct Cryptonight_R_generator
 	template<xmrstak_algo_id ALGO>
 	static void cn_on_new_job(const xmrstak::miner_work& work, cryptonight_ctx** ctx)
 	{
-		if(ctx[0]->cn_r_ctx.height == work.iBlockHeight && ctx[0]->last_algo == POW(cryptonight_r))
+		if(ctx[0]->cn_r_ctx.height == work.iBlockHeight &&
+			ctx[0]->last_algo == POW(cryptonight_r) &&
+			reinterpret_cast<void*>(ctx[0]->hash_fn) == ctx[0]->fun_data
+		)
 			return;
 
 		ctx[0]->last_algo = POW(cryptonight_r);


### PR DESCRIPTION
fix #2307

If the miner changed the pool (user pool or dev pool) and the network
block of monero has not changed the miner switch to the non asm version.

Add check if the hash function has changed. If the hash function not
point to the asm version the ASM function is recreated.
