### PR TITLE
Fix CN_MASK

### DIFF
--- a/xmrstak/backend/cryptonight.hpp
+++ b/xmrstak/backend/cryptonight.hpp
@@ -183,7 +183,7 @@ struct xmrstak_algo
 // default cryptonight
 constexpr size_t CN_MEMORY = 2 * 1024 * 1024;
 constexpr uint32_t CN_ITER = 0x80000;
-CN_MASK = (CN_MEMORY / 16 - 1) * 16;
+constexpr uint32_t CN_MASK = (CN_MEMORY / 16 - 1) * 16;
 
 // crptonight gpu
 constexpr uint32_t CN_GPU_MASK = 0x1FFFC0;

--- a/xmrstak/backend/cryptonight.hpp
+++ b/xmrstak/backend/cryptonight.hpp
@@ -168,7 +168,7 @@ struct xmrstak_algo
 	{
 		// default is a 16 byte aligne mask
 		if(mask == 0)
-			return ((mem - 1u) / 16) * 16;
+			return (mem / 16 - 1u) * 16;
 		else
 			return mask;
 	}
@@ -183,7 +183,7 @@ struct xmrstak_algo
 // default cryptonight
 constexpr size_t CN_MEMORY = 2 * 1024 * 1024;
 constexpr uint32_t CN_ITER = 0x80000;
-constexpr uint32_t CN_MASK = ((CN_MEMORY - 1) / 16) * 16;
+CN_MASK = (CN_MEMORY / 16 - 1) * 16;
 
 // crptonight gpu
 constexpr uint32_t CN_GPU_MASK = 0x1FFFC0;


### PR DESCRIPTION
"CN_MASK = ((CN_MEMORY - 1) / 16) * 16;" == "CN_MASK = CN_MEMORY - 1;"
Current implementation only does -1. 16/16 is 1 so code is doing nothing.

The correct operation is this one: constexpr uint32_t CN_MASK = (CN_MEMORY / 16 - 1) * 16;

I think this const is not used anywhere, but I would fix It.

Please make sure your PR is against **dev** branch. Merging PRs directly into master branch would interfere with our workflow.