### PR TITLE
Don't fail with "use_slow_memory" == "warn" and --noUAC on Windows 7, 8

### DIFF
--- a/xmrstak/misc/uac.cpp
+++ b/xmrstak/misc/uac.cpp
@@ -1,6 +1,7 @@
 #ifdef _WIN32
 #include "xmrstak/misc/console.hpp"
 #include "xmrstak/params.hpp"
+#include "xmrstak/jconf.hpp"
 
 #include <string>
 #include <windows.h>
@@ -56,6 +57,9 @@ VOID RequestElevation()
 	if(!xmrstak::params::inst().allowUAC)
 	{
 		printer::inst()->print_msg(L0, "The miner needs to run as administrator, but you passed --noUAC option. Please remove it or set use_slow_memory to always.");
+		if (::jconf::inst()->GetSlowMemSetting() == ::jconf::print_warning)
+			return;
+		
 		win_exit();
 		return;
 	}


### PR DESCRIPTION
These conditions combined make the miner terminate:

- `"use_slow_memory"` == `"warn"`
- `--noUAC`
- Windows 7 or 8

[The code](https://github.com/fireice-uk/xmr-stak/blob/a5b8fb741b17307871681ef0eab6fd4cf224b6df/xmrstak/cli/cli-miner.cpp#L769) where the termination happens. This breaks the expected behavior of the `warn` option on Win 7 and 8,