### PR TITLE
Multiple pools via CLI

### DIFF
--- a/xmrstak/params.hpp
+++ b/xmrstak/params.hpp
@@ -4,9 +4,22 @@
 #include "xmrstak/misc/home_dir.hpp"
 
 #include <string>
+#include <vector>
 
 namespace xmrstak
 {
+
+struct pool
+{
+	bool poolUseTls = false;
+	std::string poolURL;
+	bool userSetPwd = false;
+	std::string poolPasswd;
+	bool userSetRigid = false;
+	std::string poolRigid;
+	std::string poolUsername;
+	bool nicehashMode = false;
+};
 
 struct params
 {
@@ -30,14 +43,7 @@ struct params
 	// user selected OpenCL vendor
 	std::string openCLVendor;
 
-	bool poolUseTls = false;
-	std::string poolURL;
-	bool userSetPwd = false;
-	std::string poolPasswd;
-	bool userSetRigid = false;
-	std::string poolRigid;
-	std::string poolUsername;
-	bool nicehashMode = false;
+	std::vector<pool> pools;
 
 	static constexpr int32_t httpd_port_unset = -1;
 	static constexpr int32_t httpd_port_disabled = 0;


### PR DESCRIPTION
Supply multiple pools via CLI options by using pool-related options multiple times.

Better CLI options functionality makes xmr-stak easier to integrate, because command line parameters are generally easier to manage programmatically.