### PR TITLE
Topic rename coin stellite

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Besides [Monero](https://getmonero.org), following coins can be mined using this
 - [Plenteum](https://www.plenteum.com/)
 - [QRL](https://theqrl.org)
 - **[Ryo](https://ryo-currency.com) - Upcoming xmr-stak-gui is sponsored by Ryo**
-- [Stellite](https://stellite.cash/)
+- [Torque](https://torque.cash/)
 - [TurtleCoin](https://turtlecoin.lol)
 - [Zelerius](https://zelerius.org/)
 - [X-CASH](https://x-network.io/)
@@ -72,7 +72,7 @@ If your prefered coin is not listed, you can choose one of the following algorit
     - cryptonight_v7_stellite
     - cryptonight_v8
     - cryptonight_v8_double (used by X-CASH)
-    - cryptonight_v8_half (used by masari and stellite)
+    - cryptonight_v8_half (used by masari and torque)
     - cryptonight_v8_reversewaltz (used by graft)
     - cryptonight_v8_zelerius
 - 4MiB scratchpad memory

--- a/xmrstak/jconf.cpp
+++ b/xmrstak/jconf.cpp
@@ -132,7 +132,7 @@ xmrstak::coin_selection coins[] = {
 	{"monero", {POW(cryptonight_r)}, {POW(cryptonight_r)}, "pool.usxmrpool.com:3333"},
 	{"qrl", {POW(cryptonight_monero)}, {POW(cryptonight_gpu)}, nullptr},
 	{"ryo", {POW(cryptonight_gpu)}, {POW(cryptonight_gpu)}, "pool.ryo-currency.com:3333"},
-	{"stellite", {POW(cryptonight_v8_half)}, {POW(cryptonight_gpu)}, nullptr},
+	{"torque", {POW(cryptonight_v8_half)}, {POW(cryptonight_gpu)}, nullptr},
 	{"turtlecoin", {POW(cryptonight_turtle), 6u, POW(cryptonight_aeon)}, {POW(cryptonight_aeon)}, nullptr},
 	{"plenteum", {POW(cryptonight_turtle)}, {POW(cryptonight_turtle)}, nullptr},
 	{"zelerius", {POW(cryptonight_v8_zelerius), 7, POW(cryptonight_monero_v8)}, {POW(cryptonight_gpu)}, nullptr},

--- a/xmrstak/pools.tpl
+++ b/xmrstak/pools.tpl
@@ -32,6 +32,7 @@ POOLCONF],
  *    ryo
  *    turtlecoin
  *    plenteum
+ *    torque
  *    xcash
  *
  * Native algorithms which do not depend on any block versions:
@@ -49,7 +50,7 @@ POOLCONF],
  *    cryptonight_v7
  *    cryptonight_v8
  *    cryptonight_v8_double (used by xcash)
- *    cryptonight_v8_half (used by masari and stellite)
+ *    cryptonight_v8_half (used by masari and torque)
  *    cryptonight_v8_reversewaltz (used by graft)
  *    cryptonight_v8_zelerius
  *    # 4MiB scratchpad memory


### PR DESCRIPTION
Please make sure your PR is against **dev** branch. Merging PRs directly into master branch would interfere with our workflow.

I have not changed the internal name `cryptonight_stellite` for the old POW of stellite.
If I need a procrastination task I will remove older cryptonight variants those are not longer used by the coins we support in a separate PR. 