### PR TITLE
 Per-GPU hashrate and shares in CLI

### DIFF
--- a/xmrstak/backend/amd/minethd.cpp
+++ b/xmrstak/backend/amd/minethd.cpp
@@ -53,6 +53,7 @@ minethd::minethd(miner_work& pWork, size_t iNo, GpuContext* ctx, const jconf::th
 	oWork = pWork;
 	bQuit = 0;
 	iThreadNo = (uint8_t)iNo;
+	this->iGpuIndex = cfg.index;
 	iJobNo = 0;
 	iHashCount = 0;
 	iTimestamp = 0;

--- a/xmrstak/backend/iBackend.hpp
+++ b/xmrstak/backend/iBackend.hpp
@@ -46,6 +46,7 @@ struct iBackend
 	std::atomic<uint64_t> iHashCount;
 	std::atomic<uint64_t> iTimestamp;
 	uint32_t iThreadNo;
+	uint32_t iGpuIndex;
 	BackendType backendType = UNKNOWN;
 	uint64_t iLastStamp = get_timestamp_ms();
 	double avgHashPerMsec = 0.0;

--- a/xmrstak/backend/nvidia/minethd.cpp
+++ b/xmrstak/backend/nvidia/minethd.cpp
@@ -70,6 +70,7 @@ minethd::minethd(miner_work& pWork, size_t iNo, const jconf::thd_cfg& cfg)
 	oWork = pWork;
 	bQuit = 0;
 	iThreadNo = (uint8_t)iNo;
+	this->iGpuIndex = cfg.id;
 	iJobNo = 0;
 
 	ctx.device_id = (int)cfg.id;

--- a/xmrstak/misc/executor.cpp
+++ b/xmrstak/misc/executor.cpp
@@ -440,17 +440,35 @@ void executor::on_miner_result(size_t pool_id, job_result& oResult)
 		t_len = 0xFFFF;
 	iPoolCallTimes.push_back((uint16_t)t_len);
 
+	std::string name(backend_name);
+	std::transform(name.begin(), name.end(), name.begin(), ::toupper);
+
 	if(bResult)
 	{
 		uint64_t* targets = (uint64_t*)oResult.bResult;
 		log_result_ok(t64_to_diff(targets[3]));
-		printer::inst()->print_msg(L3, "Result accepted by the pool.");
+
+		if (pvThreads->at(oResult.iThreadId)->backendType == xmrstak::iBackend::BackendType::CPU)
+		{
+			printer::inst()->print_msg(L3, "CPU: Share accepted. Pool: %s", pool->get_pool_addr());
+		}
+		else
+		{
+			printer::inst()->print_msg(L3, "%s GPU %u: Share accepted. Pool: %s", name.c_str(), pvThreads->at(oResult.iThreadId)->iGpuIndex, pool->get_pool_addr());
+		}
 	}
 	else
 	{
 		if(!pool->have_sock_error())
 		{
-			printer::inst()->print_msg(L3, "Result rejected by the pool.");
+			if (pvThreads->at(oResult.iThreadId)->backendType == xmrstak::iBackend::BackendType::CPU)
+			{
+				printer::inst()->print_msg(L3, "CPU: Share rejected. Pool: %s", pool->get_pool_addr());
+			}
+			else
+			{
+				printer::inst()->print_msg(L3, "%s GPU %u: Share rejected. Pool: %s", name.c_str(), pvThreads->at(oResult.iThreadId)->iGpuIndex, pool->get_pool_addr());
+			}
 
 			std::string error = pool->get_call_error();
 


### PR DESCRIPTION
- Hashrate totals by GPU.
- For each accepted/rejected share, print responsible GPU and pool.

Hashrate report example:

```
HASHRATE REPORT - CPU
| ID |    10s |    60s |    15m |
|  0 |    1.5 |   (na) |   (na) |

Totals (CPU):     1.5    0.0    0.0 H/s
-----------------------------------------------------------------
HASHRATE REPORT - AMD
| ID |    10s |    60s |    15m |
GPU 0:
|  0 |  172.9 |   (na) |   (na) |
|  1 |  166.5 |   (na) |   (na) |
Totals (GPU 0):   339.4    0.0    0.0 H/s
GPU 1:
|  2 |  199.0 |   (na) |   (na) |
|  3 |  196.2 |   (na) |   (na) |
Totals (GPU 1):   395.2    0.0    0.0 H/s

Totals (AMD):   734.5    0.0    0.0 H/s
-----------------------------------------------------------------
Totals (ALL):    736.0    0.0    0.0 H/s
Highest:   761.2 H/s
-----------------------------------------------------------------
```

```
[2019-05-02 04:23:29] : AMD GPU 0: Share accepted. Pool: somepool:8050
```