### PR TITLE
Fallback from hwloc autoconf to basic autoconf

### DIFF
--- a/xmrstak/backend/cpu/autoAdjustHwloc.hpp
+++ b/xmrstak/backend/cpu/autoAdjustHwloc.hpp
@@ -21,10 +21,10 @@ namespace xmrstak
 namespace cpu
 {
 
-class autoAdjust
+class autoAdjustHwloc
 {
-  public:
-	autoAdjust()
+public:
+	autoAdjustHwloc()
 	{
 		auto neededAlgorithms = ::jconf::inst()->GetCurrentCoinSelection().GetAllAlgorithms();
 
@@ -60,6 +60,7 @@ class autoAdjust
 			conf += "/*\n//CPU config is disabled by default because cryptonight_gpu is not suitable for CPU mining.\n";
 		}
 
+		bool is_successful = true;
 		try
 		{
 			std::vector<hwloc_obj_t> tlcs;
@@ -86,10 +87,8 @@ class autoAdjust
 		}
 		catch(const std::runtime_error& err)
 		{
-			// \todo add fallback to default auto adjust
-			conf += std::string("    { \"low_power_mode\" : false");
-			conf += std::string(", \"no_prefetch\" : true, \"asm\" : \"off\", \"affine_to_cpu\" : false },\n");
-			printer::inst()->print_msg(L0, "Autoconf FAILED: %s. Create config for a single thread.", err.what());
+			is_successful = false;
+			printer::inst()->print_msg(L0, "Autoconf with hwloc FAILED: %s. Trying basic autoconf.", err.what());
 		}
 
 		if(useCryptonight_gpu)
@@ -101,7 +100,7 @@ class autoAdjust
 		/* Destroy topology object. */
 		hwloc_topology_destroy(topology);
 
-		return true;
+		return is_successful;
 	}
 
   private:

--- a/xmrstak/backend/cpu/minethd.cpp
+++ b/xmrstak/backend/cpu/minethd.cpp
@@ -40,6 +40,7 @@
 
 #ifndef CONF_NO_HWLOC
 #include "autoAdjustHwloc.hpp"
+#include "autoAdjust.hpp"
 #else
 #include "autoAdjust.hpp"
 #endif
@@ -515,9 +516,23 @@ std::vector<iBackend*> minethd::thread_starter(uint32_t threadOffset, miner_work
 
 	if(!configEditor::file_exist(params::inst().configFileCPU))
 	{
+#ifndef CONF_NO_HWLOC
+		autoAdjustHwloc adjustHwloc;
+		if(!adjustHwloc.printConfig())
+		{
+			autoAdjust adjust;
+			if(!adjust.printConfig())
+			{
+				return pvThreads;
+			}
+		}
+#else
 		autoAdjust adjust;
 		if(!adjust.printConfig())
+		{
 			return pvThreads;
+		}
+#endif
 	}
 
 	if(!jconf::inst()->parse_config())


### PR DESCRIPTION
If hwloc autoconf does not work, fall back to the basic autoconf.

This provides a better guess for some CPUs for which hwloc autoconf fails. This was marked as "TODO" in the code.