### PR TITLE
fix useless mutex

### DIFF
--- a/xmrstak/misc/telemetry.hpp
+++ b/xmrstak/misc/telemetry.hpp
@@ -1,10 +1,7 @@
 #pragma once
 
-#include "xmrstak/cpputil/read_write_lock.h"
-
 #include <cstdint>
 #include <cstring>
-#include <mutex>
 
 namespace xmrstak
 {
@@ -17,7 +14,6 @@ class telemetry
 	double calc_telemetry_data(size_t iLastMillisec, size_t iThread);
 
   private:
-	::cpputil::RWLock* mtx;
 	constexpr static size_t iBucketSize = 2 << 11; //Power of 2 to simplify calculations
 	constexpr static size_t iBucketMask = iBucketSize - 1;
 	uint32_t* iBucketTop;


### PR DESCRIPTION
solve partly #2514

Remove a mutex which is not needed at all because all data are accessed
from one thread only.