### PR TITLE
fix singletons

### DIFF
--- a/xmrstak/backend/cpu/crypto/cryptonight.h
+++ b/xmrstak/backend/cpu/crypto/cryptonight.h
@@ -39,6 +39,7 @@ struct cryptonight_ctx
 	union {
 		extra_ctx_r cn_r_ctx;
 	};
+
 };
 
 struct alloc_msg

--- a/xmrstak/backend/globalStates.hpp
+++ b/xmrstak/backend/globalStates.hpp
@@ -17,7 +17,11 @@ struct globalStates
 	{
 		auto& env = environment::inst();
 		if(env.pglobalStates == nullptr)
-			env.pglobalStates = new globalStates;
+		{
+			std::unique_lock<std::mutex> lck(env.update);
+			if(env.pglobalStates == nullptr)
+				env.pglobalStates = new globalStates;
+		}
 		return *env.pglobalStates;
 	}
 

--- a/xmrstak/jconf.hpp
+++ b/xmrstak/jconf.hpp
@@ -14,7 +14,11 @@ class jconf
 	{
 		auto& env = xmrstak::environment::inst();
 		if(env.pJconfConfig == nullptr)
-			env.pJconfConfig = new jconf;
+		{
+			std::unique_lock<std::mutex> lck(env.update);
+			if(env.pJconfConfig == nullptr)
+				env.pJconfConfig = new jconf;
+		}
 		return env.pJconfConfig;
 	};
 

--- a/xmrstak/misc/console.hpp
+++ b/xmrstak/misc/console.hpp
@@ -48,7 +48,11 @@ class printer
 	{
 		auto& env = xmrstak::environment::inst();
 		if(env.pPrinter == nullptr)
-			env.pPrinter = new printer;
+		{
+			std::unique_lock<std::mutex> lck(env.update);
+			if(env.pPrinter == nullptr)
+				env.pPrinter = new printer;
+		}
 		return env.pPrinter;
 	};
 

--- a/xmrstak/misc/environment.cpp
+++ b/xmrstak/misc/environment.cpp
@@ -1,0 +1,19 @@
+#include "environment.hpp"
+
+#include "xmrstak/misc/console.hpp"
+#include "xmrstak/backend/cpu/crypto/cryptonight.h"
+#include "xmrstak/params.hpp"
+#include "xmrstak/misc/executor.hpp"
+#include "xmrstak/jconf.hpp"
+
+namespace xmrstak
+{
+void environment::init_singeltons()
+{
+	printer::inst();
+	globalStates::inst();
+	jconf::inst();
+	executor::inst();
+	params::inst();
+}
+}

--- a/xmrstak/misc/environment.hpp
+++ b/xmrstak/misc/environment.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <mutex>
+
 class printer;
 class jconf;
 class executor;
@@ -19,7 +21,10 @@ struct environment
 		if(env == nullptr)
 		{
 			if(init == nullptr)
+			{
 				env = new environment;
+				env->init_singeltons();
+			}
 			else
 				env = init;
 		}
@@ -36,6 +41,11 @@ struct environment
 	jconf* pJconfConfig = nullptr;
 	executor* pExecutor = nullptr;
 	params* pParams = nullptr;
+
+	std::mutex update;
+
+private:
+	void init_singeltons();
 };
 
 } // namespace xmrstak

--- a/xmrstak/misc/executor.hpp
+++ b/xmrstak/misc/executor.hpp
@@ -32,7 +32,11 @@ class executor
 	{
 		auto& env = xmrstak::environment::inst();
 		if(env.pExecutor == nullptr)
-			env.pExecutor = new executor;
+		{
+			std::unique_lock<std::mutex> lck(env.update);
+			if(env.pExecutor == nullptr)
+				env.pExecutor = new executor;
+		}
 		return env.pExecutor;
 	};
 

--- a/xmrstak/params.hpp
+++ b/xmrstak/params.hpp
@@ -15,7 +15,11 @@ struct params
 	{
 		auto& env = environment::inst();
 		if(env.pParams == nullptr)
-			env.pParams = new params;
+		{
+			std::unique_lock<std::mutex> lck(env.update);
+			if(env.pParams == nullptr)
+				env.pParams = new params;
+		}
 		return *env.pParams;
 	}
 


### PR DESCRIPTION
Since we can not implement clean image book singletons (windows
issues with shared libraries) we used a hierarchical to "emulate"
singletons. During the creation race conditions are possible.
This PR will handle the race-conditions with a mutex, since we pass the
creation of a singleton creation only ones we have no performance issue.
