### PR TITLE
fix locking to secure affinity update

### DIFF
--- a/xmrstak/backend/amd/minethd.cpp
+++ b/xmrstak/backend/amd/minethd.cpp
@@ -170,7 +170,7 @@ void minethd::work_main()
 
 	order_fix.set_value();
 	std::unique_lock<std::mutex> lck(thd_aff_set);
-	lck.release();
+	lck.unlock();
 	std::this_thread::yield();
 
 	cryptonight_ctx* cpu_ctx;

--- a/xmrstak/backend/cpu/minethd.cpp
+++ b/xmrstak/backend/cpu/minethd.cpp
@@ -843,7 +843,7 @@ void minethd::multiway_work_main()
 
 	order_fix.set_value();
 	std::unique_lock<std::mutex> lck(thd_aff_set);
-	lck.release();
+	lck.unlock();
 	std::this_thread::yield();
 
 	cryptonight_ctx* ctx[MAX_N];

--- a/xmrstak/backend/nvidia/minethd.hpp
+++ b/xmrstak/backend/nvidia/minethd.hpp
@@ -42,6 +42,7 @@ class minethd : public iBackend
 
 	std::promise<void> numa_promise;
 	std::promise<void> thread_work_promise;
+	std::mutex thd_aff_set;
 
 	// block thread until all NVIDIA GPUs are initialized
 	std::future<void> thread_work_guard;


### PR DESCRIPTION
fix #2514

- use `unlock()` instead of `release()`
- fix NVIDIA affinity setting
