### PR TITLE
[RX] fix hwloc warning

### DIFF
--- a/xmrstak/backend/cpu/hwlocMemory.cpp
+++ b/xmrstak/backend/cpu/hwlocMemory.cpp
@@ -6,6 +6,24 @@
 
 #include <hwloc.h>
 
+static __hwloc_inline int
+xmrstak_set_membind_nodeset(hwloc_topology_t topology, hwloc_const_nodeset_t nodeset, hwloc_membind_policy_t policy, int flags)
+{
+#if HWLOC_API_VERSION >= 0x20000
+	return hwloc_set_membind(
+		topology,
+		nodeset,
+		policy,
+		flags| HWLOC_MEMBIND_BYNODESET);
+#else
+	return hwloc_set_membind_nodeset(
+		topology,
+		nodeset,
+		policy,
+		flags);
+#endif
+}
+
 /** pin memory to NUMA node
  *
  * Set the default memory policy for the current thread to bind memory to the
@@ -37,7 +55,7 @@ void bindMemoryToNUMANode(size_t puId)
 		hwloc_obj_t pu = hwloc_get_obj_by_depth(topology, depth, i);
 		if(pu->os_index == puId)
 		{
-			if(0 > hwloc_set_membind_nodeset(
+			if(0 > xmrstak_set_membind_nodeset(
 					   topology,
 					   pu->nodeset,
 					   HWLOC_MEMBIND_BIND,


### PR DESCRIPTION
- fix warning depricated `hwloc_set_membind_nodeset` (since hwloc 2.0)


- [x] rebase against #2553 required
