### PR TITLE
[RX] fix irgnored tls on first start

### DIFF
--- a/xmrstak/cli/cli-miner.cpp
+++ b/xmrstak/cli/cli-miner.cpp
@@ -219,7 +219,7 @@ void do_guided_pool_config()
 	configTpl.set(std::string(tpl));
 	bool prompted = false;
 
-	auto& currency = params::inst().currency;
+	auto currency = params::inst().currency;
 	if(currency.empty() || !jconf::IsOnAlgoList(currency))
 	{
 		prompt_once(prompted);
@@ -236,7 +236,7 @@ void do_guided_pool_config()
 		currency = tmp;
 	}
 
-	auto& pool = params::inst().poolURL;
+	auto pool = params::inst().poolURL;
 	bool userSetPool = true;
 	if(pool.empty())
 	{
@@ -247,7 +247,7 @@ void do_guided_pool_config()
 		std::cin >> pool;
 	}
 
-	auto& userName = params::inst().poolUsername;
+	auto userName = params::inst().poolUsername;
 	if(userName.empty())
 	{
 		prompt_once(prompted);
@@ -257,7 +257,7 @@ void do_guided_pool_config()
 	}
 
 	bool stdin_flushed = false;
-	auto& passwd = params::inst().poolPasswd;
+	auto passwd = params::inst().poolPasswd;
 	if(passwd.empty() && !params::inst().userSetPwd)
 	{
 		prompt_once(prompted);
@@ -271,7 +271,7 @@ void do_guided_pool_config()
 		getline(std::cin, passwd);
 	}
 
-	auto& rigid = params::inst().poolRigid;
+	auto rigid = params::inst().poolRigid;
 	if(rigid.empty() && !params::inst().userSetRigid)
 	{
 		if(!use_simple_start())
@@ -366,7 +366,7 @@ void do_guided_config()
 	configTpl.set(std::string(tpl));
 	bool prompted = false;
 
-	auto& http_port = params::inst().httpd_port;
+	auto http_port = params::inst().httpd_port;
 	if(http_port == params::httpd_port_unset)
 	{
 		http_port = params::httpd_port_disabled;

--- a/xmrstak/misc/executor.cpp
+++ b/xmrstak/misc/executor.cpp
@@ -525,8 +525,9 @@ void executor::ex_main()
 			const char* rigid = params.userSetRigid ? params.poolRigid.c_str() : cfg.sRigId;
 			const char* pwd = params.userSetPwd ? params.poolPasswd.c_str() : cfg.sPasswd;
 			bool nicehash = cfg.nicehash || params.nicehashMode;
+			bool tls = params.poolUseTls;
 
-			pools.emplace_back(i, cfg.sPoolAddr, wallet, rigid, pwd, 9.9, params.poolUseTls, cfg.tls_fingerprint, nicehash);
+			pools.emplace_back(i, cfg.sPoolAddr, wallet, rigid, pwd, 9.9, tls, cfg.tls_fingerprint, nicehash);
 		}
 		else
 			pools.emplace_back(i, cfg.sPoolAddr, cfg.sWalletAddr, cfg.sRigId, cfg.sPasswd, cfg.weight, cfg.tls, cfg.tls_fingerprint, cfg.nicehash);


### PR DESCRIPTION
- during the start of the miner and the guided setup the tls settings
was ignored.
- fix that parameters from the guided start is passed to the parameter singleton
