### PR TITLE
[RX] rename shared libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -488,17 +488,17 @@ if(CUDA_FOUND)
     if(CUDA_COMPILER STREQUAL "clang")
         # build device code with clang
         add_library(
-            xmrstak_cuda_backend
+            xmrstakrx_cuda_backend
             SHARED
             ${CUDASRCFILES}
         )
-        set_target_properties(xmrstak_cuda_backend PROPERTIES COMPILE_FLAGS ${CLANG_BUILD_FLAGS})
-        set_target_properties(xmrstak_cuda_backend PROPERTIES LINKER_LANGUAGE CXX)
+        set_target_properties(xmrstakrx_cuda_backend PROPERTIES COMPILE_FLAGS ${CLANG_BUILD_FLAGS})
+        set_target_properties(xmrstakrx_cuda_backend PROPERTIES LINKER_LANGUAGE CXX)
         set_source_files_properties(${CUDASRCFILES} PROPERTIES LANGUAGE CXX)
     else()
         #  build device code with nvcc
         cuda_add_library(
-            xmrstak_cuda_backend
+            xmrstakrx_cuda_backend
             SHARED
             ${CUDASRCFILES}
         )
@@ -506,8 +506,8 @@ if(CUDA_FOUND)
 
     set(CUDA_LIBRARIES ${CUDA_LIBRARIES})
     
-    target_link_libraries(xmrstak_cuda_backend ${CUDA_LIBRARIES})
-    target_link_libraries(xmrstak_cuda_backend xmr-stak-backend)
+    target_link_libraries(xmrstakrx_cuda_backend ${CUDA_LIBRARIES})
+    target_link_libraries(xmrstakrx_cuda_backend xmr-stak-backend)
 endif()
 
 # compile AMD backend
@@ -515,12 +515,12 @@ if(OpenCL_FOUND)
     file(GLOB OPENCLSRCFILES
         "xmrstak/backend/amd/amd_gpu/*.cpp"
         "xmrstak/backend/amd/*.cpp")
-    add_library(xmrstak_opencl_backend
+    add_library(xmrstakrx_opencl_backend
         SHARED
         ${OPENCLSRCFILES}
     )
-    target_link_libraries(xmrstak_opencl_backend ${OpenCL_LIBRARY} )
-    target_link_libraries(xmrstak_opencl_backend xmr-stak-backend)
+    target_link_libraries(xmrstakrx_opencl_backend ${OpenCL_LIBRARY} )
+    target_link_libraries(xmrstakrx_opencl_backend xmr-stak-backend)
 endif()
 
 # compile final binary
@@ -548,19 +548,19 @@ if( NOT CMAKE_INSTALL_PREFIX STREQUAL PROJECT_BINARY_DIR )
             RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}/${EXECUTABLE_OUTPUT_PATH}")
     if(CUDA_FOUND)
         if(WIN32)
-            install(TARGETS xmrstak_cuda_backend
+            install(TARGETS xmrstakrx_cuda_backend
                 RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}/${LIBRARY_OUTPUT_PATH}")
         else()
-            install(TARGETS xmrstak_cuda_backend
+            install(TARGETS xmrstakrx_cuda_backend
                 LIBRARY DESTINATION "${CMAKE_INSTALL_PREFIX}/${LIBRARY_OUTPUT_PATH}")
         endif()
     endif()
     if(OpenCL_FOUND)
         if(WIN32)
-            install(TARGETS xmrstak_opencl_backend
+            install(TARGETS xmrstakrx_opencl_backend
                 RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}/${LIBRARY_OUTPUT_PATH}")
         else()
-            install(TARGETS xmrstak_opencl_backend
+            install(TARGETS xmrstakrx_opencl_backend
                 LIBRARY DESTINATION "${CMAKE_INSTALL_PREFIX}/${LIBRARY_OUTPUT_PATH}")
         endif()
     endif()

--- a/xmrstak/backend/backendConnector.cpp
+++ b/xmrstak/backend/backendConnector.cpp
@@ -56,10 +56,6 @@ bool BackendConnector::self_test()
 
 std::vector<iBackend*>* BackendConnector::thread_starter(miner_work& pWork)
 {
-
-	//randomX_global_ctx::inst();
-//randomX_global_ctx::inst();
-
 	std::vector<iBackend*>* pvThreads = new std::vector<iBackend*>;
 
 #ifndef CONF_NO_OPENCL
@@ -67,7 +63,7 @@ std::vector<iBackend*>* BackendConnector::thread_starter(miner_work& pWork)
 	{
 		const std::string backendName = xmrstak::params::inst().openCLVendor;
 		plugin amdplugin;
-		amdplugin.load(backendName, "xmrstak_opencl_backend");
+		amdplugin.load(backendName, "xmrstakrx_opencl_backend");
 		std::vector<iBackend*>* amdThreads = amdplugin.startBackend(static_cast<uint32_t>(pvThreads->size()), pWork, environment::inst());
 		size_t numWorkers = 0u;
 		if(amdThreads != nullptr)
@@ -88,9 +84,9 @@ std::vector<iBackend*>* BackendConnector::thread_starter(miner_work& pWork)
 
 		plugin nvidiaplugin;
 #ifdef XMRSTAK_DEV_RELEASE
-		std::vector<std::string> libNames = {"xmrstak_cuda_backend_cuda10_0", "xmrstak_cuda_backend"};
+		std::vector<std::string> libNames = {"xmrstakrx_cuda_backend_cuda10_0", "xmrstakrx_cuda_backend"};
 #else
-		std::vector<std::string> libNames = {"xmrstak_cuda_backend"};
+		std::vector<std::string> libNames = {"xmrstakrx_cuda_backend"};
 #endif
 		size_t numWorkers = 0u;
 


### PR DESCRIPTION
Rename xmr-stak-rx backend libraries to avoid conflicts with xmr-stak
libraries.

fix #2571
