### PR TITLE
[RX] fix windows huge page support

### DIFF
--- a/xmrstak/backend/cpu/minethd.cpp
+++ b/xmrstak/backend/cpu/minethd.cpp
@@ -260,6 +260,12 @@ bool minethd::self_test()
 	if(res == 0 && fatal)
 		return false;
 
+	if(!params::inst().selfTest)
+	{
+		printer::inst()->print_msg(L0, "skip self test: disabled by the command line option '--noTest')");
+		return true;
+	}
+
 	cryptonight_ctx* ctx[MAX_N] = {0};
 	for(int i = 0; i < MAX_N; i++)
 	{

--- a/xmrstak/cli/cli-miner.cpp
+++ b/xmrstak/cli/cli-miner.cpp
@@ -848,14 +848,11 @@ int main(int argc, char* argv[])
 	if(strlen(jconf::inst()->GetOutputFile()) != 0)
 		printer::inst()->open_logfile(jconf::inst()->GetOutputFile());
 
-	if(params::inst().selfTest)
+	if(!BackendConnector::self_test())
 	{
-		if(!BackendConnector::self_test())
-		{
-			printer::inst()->print_msg(L0, "Self test not passed!");
-			win_exit();
-			return 1;
-		}
+		printer::inst()->print_msg(L0, "Self test not passed!");
+		win_exit();
+		return 1;
 	}
 
 	if(jconf::inst()->GetHttpdPort() != uint16_t(params::httpd_port_disabled))


### PR DESCRIPTION
fix #2598 and #2582

If the command line option `--noTest` was used the huge pages for
windows was not activated.